### PR TITLE
Modify repairs.py to display new scene name

### DIFF
--- a/custom_components/tewke/repairs.py
+++ b/custom_components/tewke/repairs.py
@@ -96,7 +96,7 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Required(scene_id, default="light"): selector.SelectSelector(
+                    vol.Required(scene_id, default=str(pending[scene_id].name)): selector.SelectSelector(
                         selector.SelectSelectorConfig(
                             options=_CONTROL_TYPE_OPTIONS,
                             mode=selector.SelectSelectorMode.DROPDOWN,


### PR DESCRIPTION
New Tewke scene configuration pop-up now shows the names of the new scene as the default drop-down value.

Fixes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the repairs flow to correctly initialize the scene dropdown field based on each pending scene's name, rather than defaulting all scenes to the "light" option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->