### PR TITLE
Add configurable default speed for fan scenes

### DIFF
--- a/custom_components/tewke/config_flow.py
+++ b/custom_components/tewke/config_flow.py
@@ -11,19 +11,22 @@ from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import selector
 
-from . import TewkeCoordinator
 from .const import (
     CONF_DEFAULT_SCENE_FAN_DIMMING,
     DEFAULT_SCENE_FAN_DIMMING,
     DOMAIN,
     LOGGER,
 )
+from .util import _get_default_scene_fan_dimming
 
 if TYPE_CHECKING:
     from pytewke.data import Scene
 
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+    from .coordinator import TewkeCoordinator
+    from .data import TewkeConfigEntry
 
 _CONTROL_TYPE_OPTIONS = [
     selector.SelectOptionDict(value="light", label="Light"),
@@ -218,8 +221,8 @@ class TewkeOptionsFlow(OptionsFlow):
         entry = self.config_entry
         scene_control_types: dict[str, str] = entry.data.get("scene_control_types", {})
 
-        coordinator: TewkeCoordinator | None = (
-            entry.runtime_data.coordinator if entry.runtime_data else None
+        coordinator: TewkeCoordinator | None = getattr(
+            getattr(entry, "runtime_data", None), "coordinator", None
         )
         scenes: dict[str, Scene] = (
             coordinator.data["scenes"] if coordinator and coordinator.data else {}
@@ -234,9 +237,7 @@ class TewkeOptionsFlow(OptionsFlow):
         if not fan_scenes:
             return self.async_abort(reason="no_fan_scenes")
 
-        current_speeds: dict[str, int] = entry.options.get(
-            CONF_DEFAULT_SCENE_FAN_DIMMING
-        ) or entry.data.get(CONF_DEFAULT_SCENE_FAN_DIMMING, {})
+        current_speeds = _get_default_scene_fan_dimming(entry)
 
         if user_input is not None:
             name_to_id = {

--- a/custom_components/tewke/config_flow.py
+++ b/custom_components/tewke/config_flow.py
@@ -2,17 +2,27 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytewke
 import voluptuous as vol
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.core import callback
 from homeassistant.helpers import selector
 
-from .const import DOMAIN, LOGGER
+from . import TewkeCoordinator
+from .const import (
+    CONF_DEFAULT_SCENE_FAN_DIMMING,
+    DEFAULT_SCENE_FAN_DIMMING,
+    DOMAIN,
+    LOGGER,
+)
 
 if TYPE_CHECKING:
+    from pytewke.data import Scene
+
+    from homeassistant.config_entries import ConfigEntry
     from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 _CONTROL_TYPE_OPTIONS = [
@@ -20,6 +30,15 @@ _CONTROL_TYPE_OPTIONS = [
     selector.SelectOptionDict(value="switch", label="Switch"),
     selector.SelectOptionDict(value="fan", label="Fan"),
 ]
+
+_FAN_SPEED_SELECTOR = selector.NumberSelector(
+    selector.NumberSelectorConfig(
+        min=1,
+        max=100,
+        step=1,
+        mode=selector.NumberSelectorMode.SLIDER,
+    )
+)
 
 
 class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -31,7 +50,15 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
     _discovered_name: str
     _room_name: str | None = None
     _scene_control_types: dict[str, str]
+    _default_scene_fan_dimming: dict[str, int]
+    _scenes: dict[str, Scene]
     _tap: pytewke.Tap | None = None
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> TewkeOptionsFlow:
+        """Return the options flow handler."""
+        return TewkeOptionsFlow()
 
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
@@ -62,7 +89,7 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
         return await self.async_step_zeroconf_confirm()
 
     async def async_step_zeroconf_confirm(
-        self, user_input: dict[str, Any] | None = None
+        self, user_input: dict[str, str] | None = None
     ) -> ConfigFlowResult:
         """Confirm the discovered device and proceed to scene setup."""
         if user_input is not None:
@@ -78,7 +105,7 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_confirm_control_types(
-        self, user_input: dict[str, Any] | None = None
+        self, user_input: dict[str, str] | None = None
     ) -> ConfigFlowResult:
         """Assign a Home Assistant platform type to each scene."""
         tap = self._tap if self._tap is not None else pytewke.Tap(self._discovered_host)
@@ -88,6 +115,7 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
             await tap.discover()
 
         scenes = await tap.get_scenes()
+        self._scenes = scenes
         LOGGER.debug("Discovered scenes: %s", scenes)
 
         if user_input is not None:
@@ -97,6 +125,12 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
                 for name, control_type in user_input.items()
                 if name in name_to_id
             }
+            fan_scene_ids = [
+                sid for sid, ct in self._scene_control_types.items() if ct == "fan"
+            ]
+            if fan_scene_ids:
+                return await self.async_step_fan_default_speeds()
+            self._default_scene_fan_dimming = {}
             return await self.async_step_placeholder()
 
         if not scenes:
@@ -117,8 +151,41 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
         )
 
+    async def async_step_fan_default_speeds(
+        self, user_input: dict[str, float] | None = None
+    ) -> ConfigFlowResult:
+        """Set a default scene dimming value for each fan scene."""
+        fan_scenes = {
+            scene_id: self._scenes[scene_id]
+            for scene_id, ct in self._scene_control_types.items()
+            if ct == "fan" and scene_id in self._scenes
+        }
+
+        if user_input is not None:
+            name_to_id = {
+                scene.name: scene_id for scene_id, scene in fan_scenes.items()
+            }
+            self._default_scene_fan_dimming = {
+                name_to_id[name]: int(value)
+                for name, value in user_input.items()
+                if name in name_to_id
+            }
+            return await self.async_step_placeholder()
+
+        return self.async_show_form(
+            step_id="fan_default_speeds",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        scene.name, default=DEFAULT_SCENE_FAN_DIMMING
+                    ): _FAN_SPEED_SELECTOR
+                    for scene in fan_scenes.values()
+                }
+            ),
+        )
+
     async def async_step_placeholder(
-        self, user_input: dict[str, Any] | None = None
+        self, user_input: dict[str, str] | None = None
     ) -> ConfigFlowResult:
         """Final confirmation before creating the config entry."""  # noqa: D401
         if user_input is not None:
@@ -129,10 +196,70 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_NAME: self._discovered_name,
                     "room_name": self._room_name,
                     "scene_control_types": self._scene_control_types or {},
+                    CONF_DEFAULT_SCENE_FAN_DIMMING: getattr(
+                        self, "_default_scene_fan_dimming", {}
+                    ),
                 },
             )
 
         return self.async_show_form(
             step_id="placeholder",
             description_placeholders={"name": self._discovered_name},
+        )
+
+
+class TewkeOptionsFlow(OptionsFlow):
+    """Handle options for the Tewke integration."""
+
+    async def async_step_init(
+        self, user_input: dict[str, float] | None = None
+    ) -> ConfigFlowResult:
+        """Manage fan default speed options."""
+        entry = self.config_entry
+        scene_control_types: dict[str, str] = entry.data.get("scene_control_types", {})
+
+        coordinator: TewkeCoordinator | None = (
+            entry.runtime_data.coordinator if entry.runtime_data else None
+        )
+        scenes: dict[str, Scene] = (
+            coordinator.data["scenes"] if coordinator and coordinator.data else {}
+        )
+
+        fan_scenes = {
+            scene_id: scene
+            for scene_id, scene in scenes.items()
+            if scene_control_types.get(scene_id) == "fan"
+        }
+
+        if not fan_scenes:
+            return self.async_abort(reason="no_fan_scenes")
+
+        current_speeds: dict[str, int] = entry.options.get(
+            CONF_DEFAULT_SCENE_FAN_DIMMING
+        ) or entry.data.get(CONF_DEFAULT_SCENE_FAN_DIMMING, {})
+
+        if user_input is not None:
+            name_to_id = {
+                scene.name: scene_id for scene_id, scene in fan_scenes.items()
+            }
+            default_scene_fan_dimming = {
+                name_to_id[name]: int(value)
+                for name, value in user_input.items()
+                if name in name_to_id
+            }
+            return self.async_create_entry(
+                data={CONF_DEFAULT_SCENE_FAN_DIMMING: default_scene_fan_dimming}
+            )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        scene.name,
+                        default=current_speeds.get(scene_id, DEFAULT_SCENE_FAN_DIMMING),
+                    ): _FAN_SPEED_SELECTOR
+                    for scene_id, scene in fan_scenes.items()
+                }
+            ),
         )

--- a/custom_components/tewke/const.py
+++ b/custom_components/tewke/const.py
@@ -6,3 +6,6 @@ LOGGER: Logger = getLogger(__package__)
 
 DOMAIN = "tewke"
 DISPATCHER_ADD_SCENES = "tewke_add_scenes"
+
+CONF_DEFAULT_SCENE_FAN_DIMMING = "default_scene_fan_dimming"
+DEFAULT_SCENE_FAN_DIMMING = 50

--- a/custom_components/tewke/coordinator.py
+++ b/custom_components/tewke/coordinator.py
@@ -47,13 +47,7 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
     in `_async_update_data` runs once on setup, after which
     "async_set_updated_data" is called by each observation callback.
 
-    Returns:
-        {
-            "scenes": dict[str, Scene],
-            "targets": dict[int, Target],
-            "sensors": SensorData | None,
-        }
-
+    See TewkeCoordinatorData for the full shape of the coordinator data.
     """
 
     config_entry: TewkeConfigEntry

--- a/custom_components/tewke/coordinator.py
+++ b/custom_components/tewke/coordinator.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, TypedDict
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pytewke.error import (
@@ -14,12 +14,31 @@ from pytewke.error import (
 from .const import LOGGER
 
 if TYPE_CHECKING:
-    from pytewke.data import ConfigData, EnergyData, RadarData, SensorData
+    from pytewke.data import (
+        ConfigData,
+        EnergyData,
+        RadarData,
+        Scene,
+        SensorData,
+        Target,
+    )
 
     from .data import TewkeConfigEntry
 
 
-class TewkeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+class TewkeCoordinatorData(TypedDict):
+    """Typed data held by TewkeCoordinator."""
+
+    scenes: dict[str, Scene]
+    scenes_all: dict[str, Scene]
+    targets: dict[int, Target]
+    sensors: SensorData | None
+    radar: RadarData | None
+    energy: EnergyData | None
+    config: ConfigData | None
+
+
+class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
     """
     Coordinator for all Tewke state (scenes, targets, sensors).
 
@@ -39,7 +58,7 @@ class TewkeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     config_entry: TewkeConfigEntry
 
-    async def _async_update_data(self) -> dict[str, Any]:
+    async def _async_update_data(self) -> TewkeCoordinatorData:
         """Fetch initial state for all resources."""
         tap = self.config_entry.runtime_data.tap
         try:
@@ -105,12 +124,12 @@ class TewkeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             LOGGER.debug("Config data not available from Tewke Tap: %s", err)
             config = None
 
-        return {
-            "scenes": configured_scenes,
-            "scenes_all": scenes_all,
-            "targets": targets,
-            "sensors": sensors,
-            "radar": radar,
-            "energy": energy,
-            "config": config,
-        }
+        return TewkeCoordinatorData(
+            scenes=configured_scenes,
+            scenes_all=scenes_all,
+            targets=targets,
+            sensors=sensors,
+            radar=radar,
+            energy=energy,
+            config=config,
+        )

--- a/custom_components/tewke/fan.py
+++ b/custom_components/tewke/fan.py
@@ -7,12 +7,9 @@ from typing import TYPE_CHECKING
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import (
-    CONF_DEFAULT_SCENE_FAN_DIMMING,
-    DEFAULT_SCENE_FAN_DIMMING,
-    DISPATCHER_ADD_SCENES,
-)
+from .const import DEFAULT_SCENE_FAN_DIMMING, DISPATCHER_ADD_SCENES
 from .scene import TewkeSceneFan
+from .util import _get_default_scene_fan_dimming
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -31,9 +28,7 @@ async def async_setup_entry(
     coordinator = entry.runtime_data.coordinator
     scene_control_types = entry.runtime_data.scene_control_types
 
-    fan_default_speeds: dict[str, int] = entry.options.get(
-        CONF_DEFAULT_SCENE_FAN_DIMMING
-    ) or entry.data.get(CONF_DEFAULT_SCENE_FAN_DIMMING, {})
+    fan_default_speeds = _get_default_scene_fan_dimming(entry)
 
     async_add_entities(
         TewkeSceneFan(
@@ -47,9 +42,7 @@ async def async_setup_entry(
 
     @callback
     def _async_add_new_scenes(scenes: list[Scene]) -> None:
-        current_dimming: dict[str, int] = entry.options.get(
-            CONF_DEFAULT_SCENE_FAN_DIMMING
-        ) or entry.data.get(CONF_DEFAULT_SCENE_FAN_DIMMING, {})
+        current_dimming = _get_default_scene_fan_dimming(entry)
         async_add_entities(
             TewkeSceneFan(
                 coordinator=coordinator,

--- a/custom_components/tewke/fan.py
+++ b/custom_components/tewke/fan.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DISPATCHER_ADD_SCENES
+from .const import (
+    CONF_DEFAULT_SCENE_FAN_DIMMING,
+    DEFAULT_SCENE_FAN_DIMMING,
+    DISPATCHER_ADD_SCENES,
+)
 from .scene import TewkeSceneFan
 
 if TYPE_CHECKING:
@@ -27,16 +31,33 @@ async def async_setup_entry(
     coordinator = entry.runtime_data.coordinator
     scene_control_types = entry.runtime_data.scene_control_types
 
+    fan_default_speeds: dict[str, int] = entry.options.get(
+        CONF_DEFAULT_SCENE_FAN_DIMMING
+    ) or entry.data.get(CONF_DEFAULT_SCENE_FAN_DIMMING, {})
+
     async_add_entities(
-        TewkeSceneFan(coordinator=coordinator, scene=scene)
+        TewkeSceneFan(
+            coordinator=coordinator,
+            scene=scene,
+            default_dimming=fan_default_speeds.get(scene_id, DEFAULT_SCENE_FAN_DIMMING),
+        )
         for scene_id, scene in coordinator.data["scenes"].items()
         if scene_control_types.get(scene_id) == "fan"
     )
 
     @callback
     def _async_add_new_scenes(scenes: list[Scene]) -> None:
+        current_dimming: dict[str, int] = entry.options.get(
+            CONF_DEFAULT_SCENE_FAN_DIMMING
+        ) or entry.data.get(CONF_DEFAULT_SCENE_FAN_DIMMING, {})
         async_add_entities(
-            TewkeSceneFan(coordinator=coordinator, scene=scene)
+            TewkeSceneFan(
+                coordinator=coordinator,
+                scene=scene,
+                default_dimming=current_dimming.get(
+                    scene.id, DEFAULT_SCENE_FAN_DIMMING
+                ),
+            )
             for scene in scenes
             if scene_control_types.get(scene.id) == "fan"
         )

--- a/custom_components/tewke/repairs.py
+++ b/custom_components/tewke/repairs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import voluptuous as vol
 from homeassistant.components.repairs import RepairsFlow
@@ -33,7 +33,7 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
         self.entry = entry
 
     async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
+        self, user_input: dict[str, str] | None = None
     ) -> FlowResult:
         """
         Handle the configuration of new scenes.

--- a/custom_components/tewke/repairs.py
+++ b/custom_components/tewke/repairs.py
@@ -96,7 +96,9 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Required(scene_id, default=str(pending[scene_id].name)): selector.SelectSelector(
+                    vol.Required(
+                        scene_id, default=str(pending[scene_id].name)
+                    ): selector.SelectSelector(
                         selector.SelectSelectorConfig(
                             options=_CONTROL_TYPE_OPTIONS,
                             mode=selector.SelectSelectorMode.DROPDOWN,

--- a/custom_components/tewke/scene.py
+++ b/custom_components/tewke/scene.py
@@ -14,7 +14,7 @@ held locally for optimistic rendering.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
@@ -101,7 +101,7 @@ class TewkeSceneEntity(TewkeEntity):
             await self.coordinator.async_request_refresh()
         except PyTewkeInvalidWallDockError:
             LOGGER.error("Attempted to set Scene while not connected to Wall Dock")
-        except (PyTewkeInvalidRequestError, RuntimeError):
+        except PyTewkeInvalidRequestError, RuntimeError:
             action = "activating" if state else "deactivating"
             LOGGER.exception("Internal error %s Tewke scene %s", action, self._scene_id)
         except (
@@ -121,11 +121,11 @@ class TewkeSceneSwitch(TewkeSceneEntity, SwitchEntity):
         """Initialise the switch."""
         super().__init__(coordinator, scene)
 
-    async def async_turn_on(self, **kwargs: Any) -> None:  # noqa: ARG002
+    async def async_turn_on(self, **_kwargs: object) -> None:
         """Activate the scene."""
         await self._async_set_scene(state=True)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # noqa: ARG002
+    async def async_turn_off(self, **_kwargs: object) -> None:
         """Deactivate the scene."""
         await self._async_set_scene(state=False)
 
@@ -145,13 +145,13 @@ class TewkeSceneLight(TewkeSceneEntity, LightEntity):
         super().__init__(coordinator, scene)
         self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: object) -> None:
         """Activate the scene, optionally at a specific brightness."""
-        ha_brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness or 255)
+        ha_brightness = int(kwargs.get(ATTR_BRIGHTNESS) or self.brightness or 255)
         tewke_brightness = _ha_to_tewke_brightness(ha_brightness)
         await self._async_set_scene(state=True, brightness=tewke_brightness)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # noqa: ARG002
+    async def async_turn_off(self, **_kwargs: object) -> None:
         """Deactivate the scene."""
         await self._async_set_scene(state=False)
 
@@ -171,9 +171,15 @@ class TewkeSceneFan(TewkeSceneEntity, FanEntity):
         | FanEntityFeature.TURN_OFF
     )
 
-    def __init__(self, coordinator: TewkeCoordinator, scene: Scene) -> None:
+    def __init__(
+        self,
+        coordinator: TewkeCoordinator,
+        scene: Scene,
+        default_dimming: int = 50,
+    ) -> None:
         """Initialise the scene fan."""
         super().__init__(coordinator, scene)
+        self._default_dimming = default_dimming
 
     async def _async_set_percentage(self, percentage: int | None) -> None:
         """Set fan speed. A percentage of 0 turns the fan off."""
@@ -190,11 +196,13 @@ class TewkeSceneFan(TewkeSceneEntity, FanEntity):
         self,
         percentage: int | None = None,
         preset_mode: str | None = None,  # noqa: ARG002
-        **kwargs: Any,  # noqa: ARG002
+        **_kwargs: object,
     ) -> None:
-        """Turn on the fan, optionally at a specific speed."""
-        await self._async_set_percentage(percentage)
+        """Turn on the fan, using the default scene dimming value if no percentage is given."""
+        await self._async_set_percentage(
+            percentage if percentage is not None else self._default_dimming
+        )
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # noqa: ARG002
+    async def async_turn_off(self, **_kwargs: object) -> None:
         """Turn off the fan."""
         await self._async_set_scene(state=False)

--- a/custom_components/tewke/scene.py
+++ b/custom_components/tewke/scene.py
@@ -147,7 +147,8 @@ class TewkeSceneLight(TewkeSceneEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs: object) -> None:
         """Activate the scene, optionally at a specific brightness."""
-        ha_brightness = int(kwargs.get(ATTR_BRIGHTNESS) or self.brightness or 255)
+        raw = kwargs.get(ATTR_BRIGHTNESS)
+        ha_brightness = int(raw) if raw is not None else (self.brightness or 255)
         tewke_brightness = _ha_to_tewke_brightness(ha_brightness)
         await self._async_set_scene(state=True, brightness=tewke_brightness)
 

--- a/custom_components/tewke/strings.json
+++ b/custom_components/tewke/strings.json
@@ -1,41 +1,56 @@
 {
-	"config": {
-		"abort": {
-			"already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-			"cannot_identify": "Unable to determine a unique ID for this device. Please check your device and network configuration.",
-			"no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
-			"single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
-		},
-		"step": {
-			"zeroconf_confirm": {
-				"description": "You are setting up the Tewke device **{name}**{room_suffix}. Click Submit to continue.",
-				"title": "Tewke device found"
-			},
-			"confirm_control_types": {
-				"description": "Choose the Home Assistant platform type for each scene.\n\n**Light** (default) — the scene appears as a dimmable light entity.\n**Switch** — use this if you want to remove brightness control entirely.\n**Fan** — use this if you want brightness or speed control, but do not want the scene to appear as a light entity.",
-				"title": "Configure scene types"
-			},
-			"placeholder": {
-				"description": "Your Tewke device **{name}** is ready to be added to Home Assistant. Click Submit to complete the setup.",
-				"title": "Final setup"
-			}
-		}
-	},
-	"issues": {
-		"new_scenes_found": {
-			"title": "New Scenes discovered",
-			"description": "New Scenes have been discovered on your Tewke device {name}.\n\nPlease configure them to make them available in Home Assistant.",
-			"fix_flow": {
-				"step": {
-					"init": {
-						"title": "Configure new Tewke scenes",
-						"description": "New scenes were found on your Tewke device {name}. Please assign a Home Assistant platform type for each new scene."
-					}
-				},
-				"abort": {
-					"no_new_scenes": "There are no new scenes pending configuration for your Tewke device {name}."
-				}
-			}
-		}
-	}
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_identify": "Unable to determine a unique ID for this device. Please check your device and network configuration.",
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    },
+    "step": {
+      "zeroconf_confirm": {
+        "description": "You are setting up the Tewke device **{name}**{room_suffix}. Click Submit to continue.",
+        "title": "Tewke device found"
+      },
+      "confirm_control_types": {
+        "description": "Choose the Home Assistant platform type for each scene.\n\n**Light** (default) — the scene appears as a dimmable light entity.\n**Switch** — use this if you want to remove brightness control entirely.\n**Fan** — use this if you want brightness or speed control, but do not want the scene to appear as a light entity.",
+        "title": "Configure scene types"
+      },
+      "fan_default_speeds": {
+        "description": "Set the default scene value (1–100) to be applied when each scene is turned on without a specific value.",
+        "title": "Default scene dimming"
+      },
+      "placeholder": {
+        "description": "Your Tewke device **{name}** is ready to be added to Home Assistant. Click Submit to complete the setup.",
+        "title": "Final setup"
+      }
+    }
+  },
+  "options": {
+    "abort": {
+      "no_fan_scenes": "No fan scenes are configured for this device."
+    },
+    "step": {
+      "init": {
+        "description": "Set the default scene value (1–100) to be applied when each scene is turned on without a specific value.",
+        "title": "Default scene dimming"
+      }
+    }
+  },
+  "issues": {
+    "new_scenes_found": {
+      "title": "New Scenes discovered",
+      "description": "New Scenes have been discovered on your Tewke device {name}.\n\nPlease configure them to make them available in Home Assistant.",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Configure new Tewke scenes",
+            "description": "New scenes were found on your Tewke device {name}. Please assign a Home Assistant platform type for each new scene."
+          }
+        },
+        "abort": {
+          "no_new_scenes": "There are no new scenes pending configuration for your Tewke device {name}."
+        }
+      }
+    }
+  }
 }

--- a/custom_components/tewke/target.py
+++ b/custom_components/tewke/target.py
@@ -12,7 +12,7 @@ Dimmable targets expose "ColorMode.BRIGHTNESS"; non-dimmable ones expose
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from pytewke.error import (
@@ -85,14 +85,13 @@ class TewkeTargetLight(TewkeEntity, LightEntity):
             return None
         return _tewke_to_ha_brightness(target.brightness)
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: object) -> None:
         """Turn on the output, optionally at a specific brightness."""
         target = self._target
         if target is None:
             return
         if ATTR_BRIGHTNESS in kwargs:
-            ha_brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
-            tewke_brightness = _ha_to_tewke_brightness(ha_brightness)
+            tewke_brightness = _ha_to_tewke_brightness(int(kwargs[ATTR_BRIGHTNESS]))
         elif target.is_dimmable:
             tewke_brightness = target.brightness if target.brightness > 0 else 100
         else:
@@ -120,7 +119,7 @@ class TewkeTargetLight(TewkeEntity, LightEntity):
         ) as e:
             LOGGER.error("Error activating Tewke target %s: %s", self._target_index, e)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # noqa: ARG002
+    async def async_turn_off(self, **_kwargs: object) -> None:
         """Turn off the output."""
         try:
             await self.coordinator.config_entry.runtime_data.tap.set_target(

--- a/custom_components/tewke/translations/en.json
+++ b/custom_components/tewke/translations/en.json
@@ -1,41 +1,56 @@
 {
-	"config": {
-		"abort": {
-			"already_configured": "Device is already configured.",
-			"cannot_identify": "Unable to determine a unique ID for this device. Please check your device and network configuration.",
-			"no_devices_found": "No devices found on the network.",
-			"single_instance_allowed": "Already configured. Only a single configuration possible."
-		},
-		"step": {
-			"zeroconf_confirm": {
-				"description": "You are setting up the Tewke device **{name}**{room_suffix}. Click Submit to continue.",
-				"title": "Tewke device found"
-			},
-			"confirm_control_types": {
-				"description": "Choose the Home Assistant platform type for each scene.\n\n**Light** (default) — the scene appears as a dimmable light entity.\n**Switch** — use this if you want to remove brightness control entirely.\n**Fan** — use this if you want brightness or speed control, but do not want the scene to appear as a light entity.",
-				"title": "Configure scene types"
-			},
-			"placeholder": {
-				"description": "Your Tewke device **{name}** is ready to be added to Home Assistant. Click Submit to complete the setup.",
-				"title": "Final setup"
-			}
-		}
-	},
-	"issues": {
-		"new_scenes_found": {
-			"title": "New Scenes discovered",
-			"description": "New Scenes have been discovered on your Tewke device {name}.\n\nPlease configure them to make them available in Home Assistant.",
-			"fix_flow": {
-				"step": {
-					"init": {
-						"title": "Configure new Tewke scenes",
-						"description": "New scenes were found on your Tewke device {name}. Please assign a Home Assistant platform type for each new scene."
-					}
-				},
-				"abort": {
-					"no_new_scenes": "There are no new scenes pending configuration for your Tewke device {name}."
-				}
-			}
-		}
-	}
+  "config": {
+    "abort": {
+      "already_configured": "Device is already configured.",
+      "cannot_identify": "Unable to determine a unique ID for this device. Please check your device and network configuration.",
+      "no_devices_found": "No devices found on the network.",
+      "single_instance_allowed": "Already configured. Only a single configuration possible."
+    },
+    "step": {
+      "zeroconf_confirm": {
+        "description": "You are setting up the Tewke device **{name}**{room_suffix}. Click Submit to continue.",
+        "title": "Tewke device found"
+      },
+      "confirm_control_types": {
+        "description": "Choose the Home Assistant platform type for each scene.\n\n**Light** (default) — the scene appears as a dimmable light entity.\n**Switch** — use this if you want to remove brightness control entirely.\n**Fan** — use this if you want brightness or speed control, but do not want the scene to appear as a light entity.",
+        "title": "Configure scene types"
+      },
+      "fan_default_speeds": {
+        "description": "Set the default scene value (1–100) to be applied when each scene is turned on without a specific value.",
+        "title": "Default scene dimming"
+      },
+      "placeholder": {
+        "description": "Your Tewke device **{name}** is ready to be added to Home Assistant. Click Submit to complete the setup.",
+        "title": "Final setup"
+      }
+    }
+  },
+  "options": {
+    "abort": {
+      "no_fan_scenes": "No fan scenes are configured for this device."
+    },
+    "step": {
+      "init": {
+        "description": "Set the default scene value (1–100) to be applied when each scene is turned on without a specific value.",
+        "title": "Default scene dimming"
+      }
+    }
+  },
+  "issues": {
+    "new_scenes_found": {
+      "title": "New Scenes discovered",
+      "description": "New Scenes have been discovered on your Tewke device {name}.\n\nPlease configure them to make them available in Home Assistant.",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Configure new Tewke scenes",
+            "description": "New scenes were found on your Tewke device {name}. Please assign a Home Assistant platform type for each new scene."
+          }
+        },
+        "abort": {
+          "no_new_scenes": "There are no new scenes pending configuration for your Tewke device {name}."
+        }
+      }
+    }
+  }
 }

--- a/custom_components/tewke/util.py
+++ b/custom_components/tewke/util.py
@@ -1,5 +1,21 @@
 """Utilities for the Tewke integration."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .const import CONF_DEFAULT_SCENE_FAN_DIMMING, DEFAULT_SCENE_FAN_DIMMING
+
+if TYPE_CHECKING:
+    from .data import TewkeConfigEntry
+
+
+def _get_default_scene_fan_dimming(entry: TewkeConfigEntry) -> dict[str, int]:
+    """Return per-scene fan dimming defaults, preferring options over initial data."""
+    return entry.options.get(CONF_DEFAULT_SCENE_FAN_DIMMING) or entry.data.get(
+        CONF_DEFAULT_SCENE_FAN_DIMMING, {}
+    )
+
 
 def _tewke_to_ha_brightness(value: int) -> int:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ requires-python = ">=3.14.2"
 dependencies = [
     "colorlog==6.10.1",
     "homeassistant==2026.3.3",
-    "ruff>=0.15.7",
     "pytewke>=0.4.0",
     "voluptuous>=0.15.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,6 @@ dependencies = [
     { name = "colorlog" },
     { name = "homeassistant" },
     { name = "pytewke" },
-    { name = "ruff" },
     { name = "voluptuous" },
 ]
 
@@ -944,8 +943,7 @@ dev = [
 requires-dist = [
     { name = "colorlog", specifier = "==6.10.1" },
     { name = "homeassistant", specifier = "==2026.3.3" },
-    { name = "pytewke", git = "https://gitlab.com/tewke/open-source/pytewke.git?rev=2eb1a9ff094db69dd6cf5007431fc47e47977f58" },
-    { name = "ruff", specifier = ">=0.15.7" },
+    { name = "pytewke", specifier = ">=0.4.0" },
     { name = "voluptuous", specifier = ">=0.15.2" },
 ]
 
@@ -1647,11 +1645,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/08/64/a99f27d3b4347486c
 [[package]]
 name = "pytewke"
 version = "0.4.0"
-source = { git = "https://gitlab.com/tewke/open-source/pytewke.git?rev=2eb1a9ff094db69dd6cf5007431fc47e47977f58#2eb1a9ff094db69dd6cf5007431fc47e47977f58" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiocoap" },
     { name = "cbor2" },
     { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/00/49fbbf51089bab0b28d126a203dfa6d1a71d7c6425937dc8491f4a530209/pytewke-0.4.0.tar.gz", hash = "sha256:a054deff2d772ab9eb305125c9a7573a78bf6a598281dbfca929166666db1b0f", size = 18000910, upload-time = "2026-04-20T15:44:09.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/94/9708db3eeb66ac5d9db75a385d6f392f3c0892fc4b2d9d5946be0f32f7e4/pytewke-0.4.0-py3-none-any.whl", hash = "sha256:9306cf2a92919241c18a1f6e6786bc8e2d570dfb672d65602547092c627f0997", size = 21116, upload-time = "2026-04-20T15:44:06.111Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Users can now set a default dimming value (1-100) for scenes configured as fan entities. This value is applied when the fan is turned on without a specific speed. The setting is available during initial configuration and via the options flow.

<img width="731" height="494" alt="image" src="https://github.com/user-attachments/assets/ee2900f1-64d4-43d3-a387-ce75ae6b918c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New setup step to set a numeric default dimming/speed (1–100) for fan scenes
  * Options panel to update default fan scene dimming after setup
  * Fan scenes now use the configured default speed when activated without an explicit percentage

* **Documentation**
  * Updated UI strings and translations to include "Default scene dimming" prompts and options
<!-- end of auto-generated comment: release notes by coderabbit.ai -->