### PR TITLE
fix: Clear stale pending scenes and repair warnings

### DIFF
--- a/custom_components/tewke/__init__.py
+++ b/custom_components/tewke/__init__.py
@@ -92,12 +92,22 @@ async def async_setup_entry(
             }
         )
 
+        # Remove pending scenes that no longer exist on the device
+        stale_ids = [
+            sid for sid in entry.runtime_data.pending_scenes if sid not in scenes
+        ]
+        for sid in stale_ids:
+            del entry.runtime_data.pending_scenes[sid]
+
         new_scenes = {
             scene_id: scene
             for scene_id, scene in scenes.items()
             if scene_id not in scene_control_types
             and scene_id not in entry.runtime_data.pending_scenes
         }
+
+        if not new_scenes and not entry.runtime_data.pending_scenes:
+            ir.async_delete_issue(hass, DOMAIN, f"new_scenes_found_{entry.entry_id}")
 
         if new_scenes:
             LOGGER.info("Discovered new scenes, pending configuration: %s", new_scenes)

--- a/custom_components/tewke/repairs.py
+++ b/custom_components/tewke/repairs.py
@@ -69,6 +69,19 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
         if user_input is not None:
             return await self._async_apply_results(user_input)
 
+        # Re-filter against current pending_scenes to drop any externally removed scenes.
+        pending: dict[str, Scene] = (
+            self.entry.runtime_data.pending_scenes
+            if hasattr(self.entry, "runtime_data")
+            else {}
+        )
+        self._pending_list = [
+            (sid, scene) for sid, scene in self._pending_list if sid in pending
+        ]
+
+        if not self._pending_list:
+            return self.async_abort(reason="no_new_scenes")
+
         schema = vol.Schema(
             {
                 vol.Required(f"scene_{i}", default="light"): _CONTROL_TYPE_SELECTOR


### PR DESCRIPTION
Previously, scenes deleted from the device could persist in the pending scenes list, leading to continuous warnings and repair flows in Home Assistant. This change ensures that non-existent scenes are removed from the pending list, clearing the associated Home Assistant issue and aborting any related repair flows.