### PR TITLE
Use sections and add disabled functionality

### DIFF
--- a/custom_components/tewke/config_flow.py
+++ b/custom_components/tewke/config_flow.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import section
 from homeassistant.helpers import selector
 
 from .const import (
@@ -21,10 +22,9 @@ from .const import (
 from .util import _get_default_scene_fan_dimming
 
 if TYPE_CHECKING:
-    from pytewke.data import Scene
-
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+    from pytewke.data import Scene
 
     from .coordinator import TewkeCoordinator
 
@@ -60,7 +60,7 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> TewkeOptionsFlow:
+    def async_get_options_flow(_config_entry: ConfigEntry) -> TewkeOptionsFlow:
         """Return the options flow handler."""
         return TewkeOptionsFlow()
 
@@ -124,21 +124,27 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             name_to_id = {scene.name: scene_id for scene_id, scene in scenes.items()}
-            self._scene_control_types = {
-                name_to_id[name]: control_type
-                for name, control_type in user_input.items()
-                if name in name_to_id
-            }
-            self._disabled_scenes = [
-                name_to_id[name]
-                for name in name_to_id
-                if not user_input.get(name, {}).get(f"Enabled", True)
-            ]
-            fan_scene_ids = [
-                sid for sid, ct in self._scene_control_types.items() if ct == "fan"
-            ]
-            if fan_scene_ids:
+            scene_configs = user_input.items()
+            self._scene_control_types = {}
+            self._disabled_scenes = []
+
+            for name, config in scene_configs:
+                if name not in name_to_id:
+                    continue
+
+                if not isinstance(config, dict) or not all(
+                    isinstance(k, str) and isinstance(v, (str, bool))
+                    for k, v in config.items()
+                ):
+                    continue
+
+                self._scene_control_types[name_to_id[name]] = config["Control type"]
+                if not config["Enabled"]:
+                    self._disabled_scenes.append(name_to_id[name])
+
+            if "fan" in self._scene_control_types.values():
                 return await self.async_step_fan_default_speeds()
+
             self._default_scene_fan_dimming = {}
             return await self.async_step_confirmation()
 
@@ -147,13 +153,21 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
 
         fields: dict = {}
         for scene in scenes.values():
-            fields[vol.Optional(f"{scene.name} enabled", default=True)] = (
-                selector.BooleanSelector()
-            )
-            fields[vol.Required(scene.name, default="light")] = selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=_CONTROL_TYPE_OPTIONS,
-                    mode=selector.SelectSelectorMode.DROPDOWN,
+            fields[vol.Required(scene.name)] = section(
+                vol.Schema(
+                    {
+                        vol.Optional(
+                            "Enabled", default=True
+                        ): selector.BooleanSelector(),
+                        vol.Required(
+                            "Control type", default="light"
+                        ): selector.SelectSelector(
+                            selector.SelectSelectorConfig(
+                                options=_CONTROL_TYPE_OPTIONS,
+                                mode=selector.SelectSelectorMode.DROPDOWN,
+                            )
+                        ),
+                    }
                 )
             )
         return self.async_show_form(

--- a/custom_components/tewke/config_flow.py
+++ b/custom_components/tewke/config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import selector
 
 from .const import (
     CONF_DEFAULT_SCENE_FAN_DIMMING,
+    CONF_DISABLED_SCENES,
     DEFAULT_SCENE_FAN_DIMMING,
     DOMAIN,
     LOGGER,
@@ -53,6 +54,7 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
     _room_name: str | None = None
     _scene_control_types: dict[str, str]
     _default_scene_fan_dimming: dict[str, int]
+    _disabled_scenes: list[str]
     _scenes: dict[str, Scene]
     _tap: pytewke.Tap | None = None
 
@@ -127,6 +129,11 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
                 for name, control_type in user_input.items()
                 if name in name_to_id
             }
+            self._disabled_scenes = [
+                name_to_id[name]
+                for name in name_to_id
+                if not user_input.get(name, {}).get(f"Enabled", True)
+            ]
             fan_scene_ids = [
                 sid for sid, ct in self._scene_control_types.items() if ct == "fan"
             ]
@@ -138,19 +145,20 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
         if not scenes:
             return await self.async_step_confirmation()
 
+        fields: dict = {}
+        for scene in scenes.values():
+            fields[vol.Optional(f"{scene.name} enabled", default=True)] = (
+                selector.BooleanSelector()
+            )
+            fields[vol.Required(scene.name, default="light")] = selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=_CONTROL_TYPE_OPTIONS,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            )
         return self.async_show_form(
             step_id="confirm_control_types",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(scene.name, default="light"): selector.SelectSelector(
-                        selector.SelectSelectorConfig(
-                            options=_CONTROL_TYPE_OPTIONS,
-                            mode=selector.SelectSelectorMode.DROPDOWN,
-                        )
-                    )
-                    for scene in scenes.values()
-                }
-            ),
+            data_schema=vol.Schema(fields),
         )
 
     async def async_step_fan_default_speeds(
@@ -201,6 +209,7 @@ class TewkeConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_DEFAULT_SCENE_FAN_DIMMING: getattr(
                         self, "_default_scene_fan_dimming", {}
                     ),
+                    CONF_DISABLED_SCENES: getattr(self, "_disabled_scenes", []),
                 },
             )
 

--- a/custom_components/tewke/const.py
+++ b/custom_components/tewke/const.py
@@ -8,4 +8,5 @@ DOMAIN = "tewke"
 DISPATCHER_ADD_SCENES = "tewke_add_scenes"
 
 CONF_DEFAULT_SCENE_FAN_DIMMING = "default_scene_fan_dimming"
+CONF_DISABLED_SCENES = "disabled_scenes"
 DEFAULT_SCENE_FAN_DIMMING = 50

--- a/custom_components/tewke/fan.py
+++ b/custom_components/tewke/fan.py
@@ -56,7 +56,8 @@ async def async_setup_entry(
                 default_dimming=current_dimming.get(
                     scene.id, DEFAULT_SCENE_FAN_DIMMING
                 ),
-                enabled_default=scene.id not in disabled_scenes,
+                enabled_default=scene.id
+                not in entry.data.get(CONF_DISABLED_SCENES, []),
             )
             for scene in scenes
             if scene_control_types.get(scene.id) == "fan"

--- a/custom_components/tewke/fan.py
+++ b/custom_components/tewke/fan.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DEFAULT_SCENE_FAN_DIMMING, DISPATCHER_ADD_SCENES
+from .const import (
+    CONF_DISABLED_SCENES,
+    DEFAULT_SCENE_FAN_DIMMING,
+    DISPATCHER_ADD_SCENES,
+)
 from .scene import TewkeSceneFan
 from .util import _get_default_scene_fan_dimming
 
@@ -27,6 +31,7 @@ async def async_setup_entry(
     """Set up Tewke fan entities from a config entry."""
     coordinator = entry.runtime_data.coordinator
     scene_control_types = entry.runtime_data.scene_control_types
+    disabled_scenes: list[str] = entry.data.get(CONF_DISABLED_SCENES, [])
 
     fan_default_speeds = _get_default_scene_fan_dimming(entry)
 
@@ -35,6 +40,7 @@ async def async_setup_entry(
             coordinator=coordinator,
             scene=scene,
             default_dimming=fan_default_speeds.get(scene_id, DEFAULT_SCENE_FAN_DIMMING),
+            enabled_default=scene_id not in disabled_scenes,
         )
         for scene_id, scene in coordinator.data["scenes"].items()
         if scene_control_types.get(scene_id) == "fan"
@@ -50,6 +56,7 @@ async def async_setup_entry(
                 default_dimming=current_dimming.get(
                     scene.id, DEFAULT_SCENE_FAN_DIMMING
                 ),
+                enabled_default=scene.id not in disabled_scenes,
             )
             for scene in scenes
             if scene_control_types.get(scene.id) == "fan"

--- a/custom_components/tewke/light.py
+++ b/custom_components/tewke/light.py
@@ -50,7 +50,8 @@ async def async_setup_entry(
             TewkeSceneLight(
                 coordinator=coordinator,
                 scene=scene,
-                enabled_default=scene.id not in disabled_scenes,
+                enabled_default=scene.id
+                not in entry.data.get(CONF_DISABLED_SCENES, []),
             )
             for scene in scenes
             if scene_control_types.get(scene.id) == "light"

--- a/custom_components/tewke/light.py
+++ b/custom_components/tewke/light.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DISPATCHER_ADD_SCENES
+from .const import CONF_DISABLED_SCENES, DISPATCHER_ADD_SCENES
 from .scene import TewkeSceneLight
 from .target import TewkeTargetLight
 
@@ -27,9 +27,14 @@ async def async_setup_entry(
     """Set up Tewke light entities from a config entry."""
     coordinator = entry.runtime_data.coordinator
     scene_control_types = entry.runtime_data.scene_control_types
+    disabled_scenes: list[str] = entry.data.get(CONF_DISABLED_SCENES, [])
 
     entities = [
-        TewkeSceneLight(coordinator=coordinator, scene=scene)
+        TewkeSceneLight(
+            coordinator=coordinator,
+            scene=scene,
+            enabled_default=scene_id not in disabled_scenes,
+        )
         for scene_id, scene in coordinator.data["scenes"].items()
         if scene_control_types.get(scene_id) == "light"
     ]
@@ -42,7 +47,11 @@ async def async_setup_entry(
     @callback
     def _async_add_new_scenes(scenes: list[Scene]) -> None:
         async_add_entities(
-            TewkeSceneLight(coordinator=coordinator, scene=scene)
+            TewkeSceneLight(
+                coordinator=coordinator,
+                scene=scene,
+                enabled_default=scene.id not in disabled_scenes,
+            )
             for scene in scenes
             if scene_control_types.get(scene.id) == "light"
         )

--- a/custom_components/tewke/repairs.py
+++ b/custom_components/tewke/repairs.py
@@ -127,6 +127,10 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
                 continue
 
             scene_id = index_name_to_id[index_name]
+            if scene_id not in pending:
+                LOGGER.warning("Scene %s no longer pending; skipping", scene_id)
+                continue
+
             added_scenes.append(pending[scene_id])
 
             new_control_types[scene_id] = config["scene_text"]

--- a/custom_components/tewke/repairs.py
+++ b/custom_components/tewke/repairs.py
@@ -6,11 +6,12 @@ from typing import TYPE_CHECKING
 
 import voluptuous as vol
 from homeassistant.components.repairs import RepairsFlow
+from homeassistant.data_entry_flow import section
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers import selector
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import DISPATCHER_ADD_SCENES, DOMAIN, LOGGER
+from .const import CONF_DISABLED_SCENES, DISPATCHER_ADD_SCENES, DOMAIN, LOGGER
 
 if TYPE_CHECKING:
     from pytewke.data import Scene
@@ -82,23 +83,35 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
         if not self._pending_list:
             return self.async_abort(reason="no_new_scenes")
 
-        schema = vol.Schema(
-            {
-                vol.Required(f"scene_{i}", default="light"): _CONTROL_TYPE_SELECTOR
-                for i in range(len(self._pending_list))
-            }
-        )
+        fields: dict = {}
+        placeholders: dict[str, str] = {"name": self.entry.title}
+        for i, (_, scene) in enumerate(self._pending_list):
+            fields[vol.Required(f"scene_section_{i}")] = section(
+                vol.Schema(
+                    {
+                        vol.Optional(
+                            f"enabled_scene_{i}", default=True
+                        ): selector.BooleanSelector(),
+                        vol.Required(
+                            f"scene_{i}", default="light"
+                        ): _CONTROL_TYPE_SELECTOR,
+                    }
+                )
+            )
+            fields[vol.Optional(f"enabled_scene_{i}", default=True)] = (
+                selector.BooleanSelector()
+            )
+
+            fields[vol.Required(f"scene_{i}", default="light")] = _CONTROL_TYPE_SELECTOR
+            placeholders[f"scene_{i}"] = scene.name
+            placeholders[f"enabled_scene_{i}"] = f"{scene.name} enabled"
+
+        schema = vol.Schema(fields)
 
         return self.async_show_form(
             step_id="configure_scenes",
             data_schema=schema,
-            description_placeholders={
-                "name": self.entry.title,
-                **{
-                    f"scene_{i}": scene.name
-                    for i, (_, scene) in enumerate(self._pending_list)
-                },
-            },
+            description_placeholders=placeholders,
         )
 
     async def _async_apply_results(self, user_input: dict[str, str]) -> FlowResult:
@@ -106,6 +119,18 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
         pending: dict[str, Scene] = self.entry.runtime_data.pending_scenes
         new_control_types = self.entry.runtime_data.scene_control_types.copy()
         added_scenes: list[Scene] = []
+
+        newly_disabled = [
+            scene_id
+            for i, (scene_id, _) in enumerate(self._pending_list)
+            if not user_input.get(f"enabled_scene_{i}", True)
+        ]
+        existing_disabled: list[str] = list(
+            self.entry.data.get(CONF_DISABLED_SCENES, [])
+        )
+        merged_disabled = existing_disabled + [
+            sid for sid in newly_disabled if sid not in existing_disabled
+        ]
 
         for i, (scene_id, scene) in enumerate(self._pending_list):
             control_type = user_input.get(f"scene_{i}", "light")
@@ -116,7 +141,11 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
 
         self.hass.config_entries.async_update_entry(
             self.entry,
-            data={**self.entry.data, "scene_control_types": new_control_types},
+            data={
+                **self.entry.data,
+                "scene_control_types": new_control_types,
+                CONF_DISABLED_SCENES: merged_disabled,
+            },
         )
         self.entry.runtime_data.scene_control_types = new_control_types
 

--- a/custom_components/tewke/repairs.py
+++ b/custom_components/tewke/repairs.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import voluptuous as vol
-from homeassistant.components import logger
 from homeassistant.components.repairs import RepairsFlow
 from homeassistant.data_entry_flow import section
 from homeassistant.helpers import issue_registry as ir
@@ -105,7 +104,9 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
             description_placeholders=placeholders,
         )
 
-    async def _async_apply_results(self, user_input: dict[str, str]) -> FlowResult:
+    async def _async_apply_results(
+        self, user_input: dict[str, dict[str, str | bool]]
+    ) -> FlowResult:
         """Commit all configured scene control types and update HA state."""
         pending: dict[str, Scene] = self.entry.runtime_data.pending_scenes
         new_control_types = self.entry.runtime_data.scene_control_types.copy()

--- a/custom_components/tewke/repairs.py
+++ b/custom_components/tewke/repairs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import voluptuous as vol
+from homeassistant.components import logger
 from homeassistant.components.repairs import RepairsFlow
 from homeassistant.data_entry_flow import section
 from homeassistant.helpers import issue_registry as ir
@@ -14,10 +15,9 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from .const import CONF_DISABLED_SCENES, DISPATCHER_ADD_SCENES, DOMAIN, LOGGER
 
 if TYPE_CHECKING:
-    from pytewke.data import Scene
-
     from homeassistant.core import HomeAssistant
     from homeassistant.data_entry_flow import FlowResult
+    from pytewke.data import Scene
 
     from .data import TewkeConfigEntry
 
@@ -47,8 +47,7 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
         self._pending_list: list[tuple[str, Scene]] = []
 
     async def async_step_init(
-        self,
-        user_input: dict[str, str] | None = None,  # noqa: ARG002
+        self, _user_input: dict[str, str] | None = None
     ) -> FlowResult:
         """Load pending scenes and hand off to the batch configuration step."""
         pending: dict[str, Scene] = (
@@ -90,27 +89,19 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
                 vol.Schema(
                     {
                         vol.Optional(
-                            f"enabled_scene_{i}", default=True
+                            "enabled_text", default=True
                         ): selector.BooleanSelector(),
                         vol.Required(
-                            f"scene_{i}", default="light"
+                            "scene_text", default="light"
                         ): _CONTROL_TYPE_SELECTOR,
                     }
                 )
             )
-            fields[vol.Optional(f"enabled_scene_{i}", default=True)] = (
-                selector.BooleanSelector()
-            )
-
-            fields[vol.Required(f"scene_{i}", default="light")] = _CONTROL_TYPE_SELECTOR
-            placeholders[f"scene_{i}"] = scene.name
-            placeholders[f"enabled_scene_{i}"] = f"{scene.name} enabled"
-
-        schema = vol.Schema(fields)
+            placeholders[f"scene_section_{i}"] = scene.name
 
         return self.async_show_form(
             step_id="configure_scenes",
-            data_schema=schema,
+            data_schema=vol.Schema(fields),
             description_placeholders=placeholders,
         )
 
@@ -119,25 +110,37 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
         pending: dict[str, Scene] = self.entry.runtime_data.pending_scenes
         new_control_types = self.entry.runtime_data.scene_control_types.copy()
         added_scenes: list[Scene] = []
+        newly_disabled = []
+        index_name_to_id = {
+            f"scene_section_{i}": sid for i, (sid, _) in enumerate(self._pending_list)
+        }
+        scene_configs = user_input.items()
 
-        newly_disabled = [
-            scene_id
-            for i, (scene_id, _) in enumerate(self._pending_list)
-            if not user_input.get(f"enabled_scene_{i}", True)
-        ]
+        for index_name, config in scene_configs:
+            if index_name not in index_name_to_id:
+                continue
+
+            if not isinstance(config, dict) or not all(
+                isinstance(k, str) and isinstance(v, (str, bool))
+                for k, v in config.items()
+            ):
+                continue
+
+            scene_id = index_name_to_id[index_name]
+            added_scenes.append(pending[scene_id])
+
+            new_control_types[scene_id] = config["scene_text"]
+            if not config["enabled_text"]:
+                newly_disabled.append(scene_id)
+
+            del pending[scene_id]
+
         existing_disabled: list[str] = list(
             self.entry.data.get(CONF_DISABLED_SCENES, [])
         )
         merged_disabled = existing_disabled + [
             sid for sid in newly_disabled if sid not in existing_disabled
         ]
-
-        for i, (scene_id, scene) in enumerate(self._pending_list):
-            control_type = user_input.get(f"scene_{i}", "light")
-            if scene_id in pending:
-                added_scenes.append(scene)
-                new_control_types[scene_id] = control_type
-                del pending[scene_id]
 
         self.hass.config_entries.async_update_entry(
             self.entry,

--- a/custom_components/tewke/repairs.py
+++ b/custom_components/tewke/repairs.py
@@ -121,10 +121,12 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
             if index_name not in index_name_to_id:
                 continue
 
-            if not isinstance(config, dict) or not all(
-                isinstance(k, str) and isinstance(v, (str, bool))
-                for k, v in config.items()
-            ):
+            if not isinstance(config, dict):
+                continue
+
+            scene_text = config.get("scene_text")
+            enabled_text = config.get("enabled_text", True)
+            if not isinstance(scene_text, str) or not isinstance(enabled_text, bool):
                 continue
 
             scene_id = index_name_to_id[index_name]
@@ -134,8 +136,8 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
 
             added_scenes.append(pending[scene_id])
 
-            new_control_types[scene_id] = config["scene_text"]
-            if not config["enabled_text"]:
+            new_control_types[scene_id] = scene_text
+            if not enabled_text:
                 newly_disabled.append(scene_id)
 
             del pending[scene_id]

--- a/custom_components/tewke/scene.py
+++ b/custom_components/tewke/scene.py
@@ -40,7 +40,9 @@ if TYPE_CHECKING:
 class TewkeSceneEntity(TewkeEntity):
     """A Tewke scene base entity."""
 
-    def __init__(self, coordinator: TewkeCoordinator, scene: Scene) -> None:
+    def __init__(
+        self, coordinator: TewkeCoordinator, scene: Scene, enabled_default: bool = True
+    ) -> None:
         """Initialise the scene light."""
         super().__init__(coordinator)
         self._scene_id = scene.id
@@ -49,6 +51,7 @@ class TewkeSceneEntity(TewkeEntity):
         self._attr_unique_id = f"{entry.unique_id or entry.entry_id}_{scene.id}"
         self._is_on = scene.is_active
         self._brightness: int | None = scene.brightness
+        self._attr_entity_registry_enabled_default = enabled_default
 
     @property
     def _scene(self) -> Scene | None:
@@ -117,9 +120,11 @@ class TewkeSceneEntity(TewkeEntity):
 class TewkeSceneSwitch(TewkeSceneEntity, SwitchEntity):
     """A Tewke scene exposed as a switch."""
 
-    def __init__(self, coordinator: TewkeCoordinator, scene: Scene) -> None:
+    def __init__(
+        self, coordinator: TewkeCoordinator, scene: Scene, enabled_default: bool = True
+    ) -> None:
         """Initialise the switch."""
-        super().__init__(coordinator, scene)
+        super().__init__(coordinator, scene, enabled_default)
 
     async def async_turn_on(self, **_kwargs: object) -> None:
         """Activate the scene."""
@@ -140,9 +145,11 @@ class TewkeSceneLight(TewkeSceneEntity, LightEntity):
 
     _attr_color_mode = ColorMode.BRIGHTNESS
 
-    def __init__(self, coordinator: TewkeCoordinator, scene: Scene) -> None:
+    def __init__(
+        self, coordinator: TewkeCoordinator, scene: Scene, enabled_default: bool = True
+    ) -> None:
         """Initialise the scene light."""
-        super().__init__(coordinator, scene)
+        super().__init__(coordinator, scene, enabled_default)
         self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
     async def async_turn_on(self, **kwargs: object) -> None:
@@ -177,9 +184,10 @@ class TewkeSceneFan(TewkeSceneEntity, FanEntity):
         coordinator: TewkeCoordinator,
         scene: Scene,
         default_dimming: int = 50,
+        enabled_default: bool = True,
     ) -> None:
         """Initialise the scene fan."""
-        super().__init__(coordinator, scene)
+        super().__init__(coordinator, scene, enabled_default)
         self._default_dimming = default_dimming
 
     async def _async_set_percentage(self, percentage: int | None) -> None:

--- a/custom_components/tewke/scene.py
+++ b/custom_components/tewke/scene.py
@@ -41,7 +41,11 @@ class TewkeSceneEntity(TewkeEntity):
     """A Tewke scene base entity."""
 
     def __init__(
-        self, coordinator: TewkeCoordinator, scene: Scene, enabled_default: bool = True
+        self,
+        coordinator: TewkeCoordinator,
+        scene: Scene,
+        *,
+        enabled_default: bool = True,
     ) -> None:
         """Initialise the scene light."""
         super().__init__(coordinator)
@@ -121,10 +125,14 @@ class TewkeSceneSwitch(TewkeSceneEntity, SwitchEntity):
     """A Tewke scene exposed as a switch."""
 
     def __init__(
-        self, coordinator: TewkeCoordinator, scene: Scene, enabled_default: bool = True
+        self,
+        coordinator: TewkeCoordinator,
+        scene: Scene,
+        *,
+        enabled_default: bool = True,
     ) -> None:
         """Initialise the switch."""
-        super().__init__(coordinator, scene, enabled_default)
+        super().__init__(coordinator, scene, enabled_default=enabled_default)
 
     async def async_turn_on(self, **_kwargs: object) -> None:
         """Activate the scene."""
@@ -146,10 +154,14 @@ class TewkeSceneLight(TewkeSceneEntity, LightEntity):
     _attr_color_mode = ColorMode.BRIGHTNESS
 
     def __init__(
-        self, coordinator: TewkeCoordinator, scene: Scene, enabled_default: bool = True
+        self,
+        coordinator: TewkeCoordinator,
+        scene: Scene,
+        *,
+        enabled_default: bool = True,
     ) -> None:
         """Initialise the scene light."""
-        super().__init__(coordinator, scene, enabled_default)
+        super().__init__(coordinator, scene, enabled_default=enabled_default)
         self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
     async def async_turn_on(self, **kwargs: object) -> None:
@@ -183,11 +195,12 @@ class TewkeSceneFan(TewkeSceneEntity, FanEntity):
         self,
         coordinator: TewkeCoordinator,
         scene: Scene,
+        *,
         default_dimming: int = 50,
         enabled_default: bool = True,
     ) -> None:
         """Initialise the scene fan."""
-        super().__init__(coordinator, scene, enabled_default)
+        super().__init__(coordinator, scene, enabled_default=enabled_default)
         self._default_dimming = default_dimming
 
     async def _async_set_percentage(self, percentage: int | None) -> None:

--- a/custom_components/tewke/strings.json
+++ b/custom_components/tewke/strings.json
@@ -1,163 +1,110 @@
 {
-  "config": {
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "cannot_identify": "Unable to determine a unique ID for this device. Please check your device and network configuration.",
-      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
-    },
-    "step": {
-      "zeroconf_confirm": {
-        "description": "You are setting up the Tewke device **{name}**{room_suffix}. Click Submit to continue.",
-        "title": "Tewke device found"
-      },
-      "confirm_control_types": {
-        "description": "Choose the Home Assistant platform type for each scene, and optionally mark scenes to start disabled.\n\n**Light** (default) \u2014 the scene appears as a dimmable light entity.\n**Switch** \u2014 use this if you want to remove brightness control entirely.\n**Fan** \u2014 use this if you want brightness or speed control, but do not want the scene to appear as a light entity.",
-        "title": "Configure scene types"
-      },
-      "fan_default_speeds": {
-        "description": "Set the default scene value (1\u2013100) to be applied when each scene is turned on without a specific value.",
-        "title": "Default scene dimming"
-      },
-      "confirmation": {
-        "description": "Your Tewke device **{name}** is ready to be added to Home Assistant. Click Submit to complete the setup.",
-        "title": "Final setup"
-      }
-    }
-  },
-  "options": {
-    "abort": {
-      "no_fan_scenes": "No fan scenes are configured for this device."
-    },
-    "step": {
-      "init": {
-        "description": "Set the default scene value (1\u2013100) to be applied when each scene is turned on without a specific value.",
-        "title": "Default scene dimming"
-      }
-    }
-  },
-  "issues": {
-    "new_scenes_found": {
-      "title": "New Scenes discovered",
-      "description": "New Scenes have been discovered on your Tewke device {name}.\n\nPlease configure them to make them available in Home Assistant.",
-      "fix_flow": {
-        "step": {
-          "configure_scenes": {
-            "title": "Configure new scenes for {name}",
-            "description": "New scenes were found on your Tewke device **{name}**. Assign a Home Assistant platform type to each one below.",
-            "data": {
-              "scene_0": "{scene_0}",
-              "scene_1": "{scene_1}",
-              "scene_2": "{scene_2}",
-              "scene_3": "{scene_3}",
-              "scene_4": "{scene_4}",
-              "scene_5": "{scene_5}",
-              "scene_6": "{scene_6}",
-              "scene_7": "{scene_7}",
-              "scene_8": "{scene_8}",
-              "scene_9": "{scene_9}",
-              "scene_10": "{scene_10}",
-              "scene_11": "{scene_11}",
-              "scene_12": "{scene_12}",
-              "scene_13": "{scene_13}",
-              "scene_14": "{scene_14}",
-              "scene_15": "{scene_15}",
-              "scene_16": "{scene_16}",
-              "scene_17": "{scene_17}",
-              "scene_18": "{scene_18}",
-              "scene_19": "{scene_19}",
-              "scene_20": "{scene_20}",
-              "scene_21": "{scene_21}",
-              "scene_22": "{scene_22}",
-              "scene_23": "{scene_23}",
-              "scene_24": "{scene_24}",
-              "scene_25": "{scene_25}",
-              "scene_26": "{scene_26}",
-              "scene_27": "{scene_27}",
-              "scene_28": "{scene_28}",
-              "scene_29": "{scene_29}",
-              "scene_30": "{scene_30}",
-              "scene_31": "{scene_31}",
-              "scene_32": "{scene_32}",
-              "scene_33": "{scene_33}",
-              "scene_34": "{scene_34}",
-              "scene_35": "{scene_35}",
-              "scene_36": "{scene_36}",
-              "scene_37": "{scene_37}",
-              "scene_38": "{scene_38}",
-              "scene_39": "{scene_39}",
-              "scene_40": "{scene_40}",
-              "scene_41": "{scene_41}",
-              "scene_42": "{scene_42}",
-              "scene_43": "{scene_43}",
-              "scene_44": "{scene_44}",
-              "scene_45": "{scene_45}",
-              "scene_46": "{scene_46}",
-              "scene_47": "{scene_47}",
-              "scene_48": "{scene_48}",
-              "scene_49": "{scene_49}",
-              "enabled_scene_0": "{enabled_scene_0}",
-              "enabled_scene_1": "{enabled_scene_1}",
-              "enabled_scene_2": "{enabled_scene_2}",
-              "enabled_scene_3": "{enabled_scene_3}",
-              "enabled_scene_4": "{enabled_scene_4}",
-              "enabled_scene_5": "{enabled_scene_5}",
-              "enabled_scene_6": "{enabled_scene_6}",
-              "enabled_scene_7": "{enabled_scene_7}",
-              "enabled_scene_8": "{enabled_scene_8}",
-              "enabled_scene_9": "{enabled_scene_9}",
-              "enabled_scene_10": "{enabled_scene_10}",
-              "enabled_scene_11": "{enabled_scene_11}",
-              "enabled_scene_12": "{enabled_scene_12}",
-              "enabled_scene_13": "{enabled_scene_13}",
-              "enabled_scene_14": "{enabled_scene_14}",
-              "enabled_scene_15": "{enabled_scene_15}",
-              "enabled_scene_16": "{enabled_scene_16}",
-              "enabled_scene_17": "{enabled_scene_17}",
-              "enabled_scene_18": "{enabled_scene_18}",
-              "enabled_scene_19": "{enabled_scene_19}",
-              "enabled_scene_20": "{enabled_scene_20}",
-              "enabled_scene_21": "{enabled_scene_21}",
-              "enabled_scene_22": "{enabled_scene_22}",
-              "enabled_scene_23": "{enabled_scene_23}",
-              "enabled_scene_24": "{enabled_scene_24}",
-              "enabled_scene_25": "{enabled_scene_25}",
-              "enabled_scene_26": "{enabled_scene_26}",
-              "enabled_scene_27": "{enabled_scene_27}",
-              "enabled_scene_28": "{enabled_scene_28}",
-              "enabled_scene_29": "{enabled_scene_29}",
-              "enabled_scene_30": "{enabled_scene_30}",
-              "enabled_scene_31": "{enabled_scene_31}",
-              "enabled_scene_32": "{enabled_scene_32}",
-              "enabled_scene_33": "{enabled_scene_33}",
-              "enabled_scene_34": "{enabled_scene_34}",
-              "enabled_scene_35": "{enabled_scene_35}",
-              "enabled_scene_36": "{enabled_scene_36}",
-              "enabled_scene_37": "{enabled_scene_37}",
-              "enabled_scene_38": "{enabled_scene_38}",
-              "enabled_scene_39": "{enabled_scene_39}",
-              "enabled_scene_40": "{enabled_scene_40}",
-              "enabled_scene_41": "{enabled_scene_41}",
-              "enabled_scene_42": "{enabled_scene_42}",
-              "enabled_scene_43": "{enabled_scene_43}",
-              "enabled_scene_44": "{enabled_scene_44}",
-              "enabled_scene_45": "{enabled_scene_45}",
-              "enabled_scene_46": "{enabled_scene_46}",
-              "enabled_scene_47": "{enabled_scene_47}",
-              "enabled_scene_48": "{enabled_scene_48}",
-              "enabled_scene_49": "{enabled_scene_49}"
-            },
-            "sections": {
-              "scene_section_0": {"name": "Hardcoded Test Title",
-                "description": "Scene {scene_0} is a {scene_type} scene."
-              }
-            }
-          }
-        },
-        "abort": {
-          "no_new_scenes": "There are no new scenes pending configuration for your Tewke device {name}."
-        }
-      }
-    }
-  }
+	"config": {
+		"abort": {
+			"already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+			"cannot_identify": "Unable to determine a unique ID for this device. Please check your device and network configuration.",
+			"no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+			"single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+		},
+		"step": {
+			"zeroconf_confirm": {
+				"description": "You are setting up the Tewke device **{name}**{room_suffix}. Click Submit to continue.",
+				"title": "Tewke device found"
+			},
+			"confirm_control_types": {
+				"description": "Choose the Home Assistant platform type for each scene, and optionally mark scenes to start disabled.\n\n**Light** (default) \u2014 the scene appears as a dimmable light entity.\n**Switch** \u2014 use this if you want to remove brightness control entirely.\n**Fan** \u2014 use this if you want brightness or speed control, but do not want the scene to appear as a light entity.",
+				"title": "Configure scene types"
+			},
+			"fan_default_speeds": {
+				"description": "Set the default scene value (1\u2013100) to be applied when each scene is turned on without a specific value.",
+				"title": "Default scene dimming"
+			},
+			"confirmation": {
+				"description": "Your Tewke device **{name}** is ready to be added to Home Assistant. Click Submit to complete the setup.",
+				"title": "Final setup"
+			}
+		}
+	},
+	"options": {
+		"abort": {
+			"no_fan_scenes": "No fan scenes are configured for this device."
+		},
+		"step": {
+			"init": {
+				"description": "Set the default scene value (1\u2013100) to be applied when each scene is turned on without a specific value.",
+				"title": "Default scene dimming"
+			}
+		}
+	},
+	"issues": {
+		"new_scenes_found": {
+			"title": "New Scenes discovered",
+			"description": "New Scenes have been discovered on your Tewke device {name}.\n\nPlease configure them to make them available in Home Assistant.",
+			"fix_flow": {
+				"step": {
+					"configure_scenes": {
+						"title": "Configure new scenes for {name}",
+						"description": "New scenes were found on your Tewke device **{name}**. Assign a Home Assistant platform type to each one below.",
+						"data": {
+							"scene_text": "Control type",
+							"enabled_text": "Enabled",
+							"scene_section_0": "{scene_section_0}",
+							"scene_section_1": "{scene_section_1}",
+							"scene_section_2": "{scene_section_2}",
+							"scene_section_3": "{scene_section_3}",
+							"scene_section_4": "{scene_section_4}",
+							"scene_section_5": "{scene_section_5}",
+							"scene_section_6": "{scene_section_6}",
+							"scene_section_7": "{scene_section_7}",
+							"scene_section_8": "{scene_section_8}",
+							"scene_section_9": "{scene_section_9}",
+							"scene_section_10": "{scene_section_10}",
+							"scene_section_11": "{scene_section_11}",
+							"scene_section_12": "{scene_section_12}",
+							"scene_section_13": "{scene_section_13}",
+							"scene_section_14": "{scene_section_14}",
+							"scene_section_15": "{scene_section_15}",
+							"scene_section_16": "{scene_section_16}",
+							"scene_section_17": "{scene_section_17}",
+							"scene_section_18": "{scene_section_18}",
+							"scene_section_19": "{scene_section_19}",
+							"scene_section_20": "{scene_section_20}",
+							"scene_section_21": "{scene_section_21}",
+							"scene_section_22": "{scene_section_22}",
+							"scene_section_23": "{scene_section_23}",
+							"scene_section_24": "{scene_section_24}",
+							"scene_section_25": "{scene_section_25}",
+							"scene_section_26": "{scene_section_26}",
+							"scene_section_27": "{scene_section_27}",
+							"scene_section_28": "{scene_section_28}",
+							"scene_section_29": "{scene_section_29}",
+							"scene_section_30": "{scene_section_30}",
+							"scene_section_31": "{scene_section_31}",
+							"scene_section_32": "{scene_section_32}",
+							"scene_section_33": "{scene_section_33}",
+							"scene_section_34": "{scene_section_34}",
+							"scene_section_35": "{scene_section_35}",
+							"scene_section_36": "{scene_section_36}",
+							"scene_section_37": "{scene_section_37}",
+							"scene_section_38": "{scene_section_38}",
+							"scene_section_39": "{scene_section_39}",
+							"scene_section_40": "{scene_section_40}",
+							"scene_section_41": "{scene_section_41}",
+							"scene_section_42": "{scene_section_42}",
+							"scene_section_43": "{scene_section_43}",
+							"scene_section_44": "{scene_section_44}",
+							"scene_section_45": "{scene_section_45}",
+							"scene_section_46": "{scene_section_46}",
+							"scene_section_47": "{scene_section_47}",
+							"scene_section_48": "{scene_section_48}",
+							"scene_section_49": "{scene_section_49}"
+						}
+					}
+				},
+				"abort": {
+					"no_new_scenes": "There are no new scenes pending configuration for your Tewke device {name}."
+				}
+			}
+		}
+	}
 }

--- a/custom_components/tewke/strings.json
+++ b/custom_components/tewke/strings.json
@@ -12,11 +12,11 @@
         "title": "Tewke device found"
       },
       "confirm_control_types": {
-        "description": "Choose the Home Assistant platform type for each scene.\n\n**Light** (default) — the scene appears as a dimmable light entity.\n**Switch** — use this if you want to remove brightness control entirely.\n**Fan** — use this if you want brightness or speed control, but do not want the scene to appear as a light entity.",
+        "description": "Choose the Home Assistant platform type for each scene, and optionally mark scenes to start disabled.\n\n**Light** (default) \u2014 the scene appears as a dimmable light entity.\n**Switch** \u2014 use this if you want to remove brightness control entirely.\n**Fan** \u2014 use this if you want brightness or speed control, but do not want the scene to appear as a light entity.",
         "title": "Configure scene types"
       },
       "fan_default_speeds": {
-        "description": "Set the default scene value (1–100) to be applied when each scene is turned on without a specific value.",
+        "description": "Set the default scene value (1\u2013100) to be applied when each scene is turned on without a specific value.",
         "title": "Default scene dimming"
       },
       "confirmation": {
@@ -31,7 +31,7 @@
     },
     "step": {
       "init": {
-        "description": "Set the default scene value (1–100) to be applied when each scene is turned on without a specific value.",
+        "description": "Set the default scene value (1\u2013100) to be applied when each scene is turned on without a specific value.",
         "title": "Default scene dimming"
       }
     }
@@ -95,7 +95,62 @@
               "scene_46": "{scene_46}",
               "scene_47": "{scene_47}",
               "scene_48": "{scene_48}",
-              "scene_49": "{scene_49}"
+              "scene_49": "{scene_49}",
+              "enabled_scene_0": "{enabled_scene_0}",
+              "enabled_scene_1": "{enabled_scene_1}",
+              "enabled_scene_2": "{enabled_scene_2}",
+              "enabled_scene_3": "{enabled_scene_3}",
+              "enabled_scene_4": "{enabled_scene_4}",
+              "enabled_scene_5": "{enabled_scene_5}",
+              "enabled_scene_6": "{enabled_scene_6}",
+              "enabled_scene_7": "{enabled_scene_7}",
+              "enabled_scene_8": "{enabled_scene_8}",
+              "enabled_scene_9": "{enabled_scene_9}",
+              "enabled_scene_10": "{enabled_scene_10}",
+              "enabled_scene_11": "{enabled_scene_11}",
+              "enabled_scene_12": "{enabled_scene_12}",
+              "enabled_scene_13": "{enabled_scene_13}",
+              "enabled_scene_14": "{enabled_scene_14}",
+              "enabled_scene_15": "{enabled_scene_15}",
+              "enabled_scene_16": "{enabled_scene_16}",
+              "enabled_scene_17": "{enabled_scene_17}",
+              "enabled_scene_18": "{enabled_scene_18}",
+              "enabled_scene_19": "{enabled_scene_19}",
+              "enabled_scene_20": "{enabled_scene_20}",
+              "enabled_scene_21": "{enabled_scene_21}",
+              "enabled_scene_22": "{enabled_scene_22}",
+              "enabled_scene_23": "{enabled_scene_23}",
+              "enabled_scene_24": "{enabled_scene_24}",
+              "enabled_scene_25": "{enabled_scene_25}",
+              "enabled_scene_26": "{enabled_scene_26}",
+              "enabled_scene_27": "{enabled_scene_27}",
+              "enabled_scene_28": "{enabled_scene_28}",
+              "enabled_scene_29": "{enabled_scene_29}",
+              "enabled_scene_30": "{enabled_scene_30}",
+              "enabled_scene_31": "{enabled_scene_31}",
+              "enabled_scene_32": "{enabled_scene_32}",
+              "enabled_scene_33": "{enabled_scene_33}",
+              "enabled_scene_34": "{enabled_scene_34}",
+              "enabled_scene_35": "{enabled_scene_35}",
+              "enabled_scene_36": "{enabled_scene_36}",
+              "enabled_scene_37": "{enabled_scene_37}",
+              "enabled_scene_38": "{enabled_scene_38}",
+              "enabled_scene_39": "{enabled_scene_39}",
+              "enabled_scene_40": "{enabled_scene_40}",
+              "enabled_scene_41": "{enabled_scene_41}",
+              "enabled_scene_42": "{enabled_scene_42}",
+              "enabled_scene_43": "{enabled_scene_43}",
+              "enabled_scene_44": "{enabled_scene_44}",
+              "enabled_scene_45": "{enabled_scene_45}",
+              "enabled_scene_46": "{enabled_scene_46}",
+              "enabled_scene_47": "{enabled_scene_47}",
+              "enabled_scene_48": "{enabled_scene_48}",
+              "enabled_scene_49": "{enabled_scene_49}"
+            },
+            "sections": {
+              "scene_section_0": {"name": "Hardcoded Test Title",
+                "description": "Scene {scene_0} is a {scene_type} scene."
+              }
             }
           }
         },

--- a/custom_components/tewke/switch.py
+++ b/custom_components/tewke/switch.py
@@ -44,7 +44,8 @@ async def async_setup_entry(
             TewkeSceneSwitch(
                 coordinator=coordinator,
                 scene=scene,
-                enabled_default=scene.id not in disabled_scenes,
+                enabled_default=scene.id
+                not in entry.data.get(CONF_DISABLED_SCENES, []),
             )
             for scene in scenes
             if scene_control_types.get(scene.id) == "switch"

--- a/custom_components/tewke/switch.py
+++ b/custom_components/tewke/switch.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DISPATCHER_ADD_SCENES
+from .const import CONF_DISABLED_SCENES, DISPATCHER_ADD_SCENES
 from .scene import TewkeSceneSwitch
 
 if TYPE_CHECKING:
@@ -26,9 +26,14 @@ async def async_setup_entry(
     """Set up Tewke switch entities from a config entry."""
     coordinator = entry.runtime_data.coordinator
     scene_control_types = entry.runtime_data.scene_control_types
+    disabled_scenes: list[str] = entry.data.get(CONF_DISABLED_SCENES, [])
 
     async_add_entities(
-        TewkeSceneSwitch(coordinator=coordinator, scene=scene)
+        TewkeSceneSwitch(
+            coordinator=coordinator,
+            scene=scene,
+            enabled_default=scene_id not in disabled_scenes,
+        )
         for scene_id, scene in coordinator.data["scenes"].items()
         if scene_control_types.get(scene_id) == "switch"
     )
@@ -36,7 +41,11 @@ async def async_setup_entry(
     @callback
     def _async_add_new_scenes(scenes: list[Scene]) -> None:
         async_add_entities(
-            TewkeSceneSwitch(coordinator=coordinator, scene=scene)
+            TewkeSceneSwitch(
+                coordinator=coordinator,
+                scene=scene,
+                enabled_default=scene.id not in disabled_scenes,
+            )
             for scene in scenes
             if scene_control_types.get(scene.id) == "switch"
         )

--- a/custom_components/tewke/translations/en.json
+++ b/custom_components/tewke/translations/en.json
@@ -12,11 +12,11 @@
         "title": "Tewke device found"
       },
       "confirm_control_types": {
-        "description": "Choose the Home Assistant platform type for each scene.\n\n**Light** (default) — the scene appears as a dimmable light entity.\n**Switch** — use this if you want to remove brightness control entirely.\n**Fan** — use this if you want brightness or speed control, but do not want the scene to appear as a light entity.",
+        "description": "Choose the Home Assistant platform type for each scene, and optionally mark scenes to start disabled.\n\n**Light** (default) \u2014 the scene appears as a dimmable light entity.\n**Switch** \u2014 use this if you want to remove brightness control entirely.\n**Fan** \u2014 use this if you want brightness or speed control, but do not want the scene to appear as a light entity.",
         "title": "Configure scene types"
       },
       "fan_default_speeds": {
-        "description": "Set the default scene value (1–100) to be applied when each scene is turned on without a specific value.",
+        "description": "Set the default scene value (1\u2013100) to be applied when each scene is turned on without a specific value.",
         "title": "Default scene dimming"
       },
       "confirmation": {
@@ -31,7 +31,7 @@
     },
     "step": {
       "init": {
-        "description": "Set the default scene value (1–100) to be applied when each scene is turned on without a specific value.",
+        "description": "Set the default scene value (1\u2013100) to be applied when each scene is turned on without a specific value.",
         "title": "Default scene dimming"
       }
     }
@@ -46,6 +46,7 @@
             "title": "Configure new scenes for {name}",
             "description": "New scenes were found on your Tewke device **{name}**. Assign a Home Assistant platform type to each one below.",
             "data": {
+              "scene_section_0": "{scene_0}",
               "scene_0": "{scene_0}",
               "scene_1": "{scene_1}",
               "scene_2": "{scene_2}",
@@ -95,7 +96,62 @@
               "scene_46": "{scene_46}",
               "scene_47": "{scene_47}",
               "scene_48": "{scene_48}",
-              "scene_49": "{scene_49}"
+              "scene_49": "{scene_49}",
+              "enabled_scene_0": "{enabled_scene_0}",
+              "enabled_scene_1": "{enabled_scene_1}",
+              "enabled_scene_2": "{enabled_scene_2}",
+              "enabled_scene_3": "{enabled_scene_3}",
+              "enabled_scene_4": "{enabled_scene_4}",
+              "enabled_scene_5": "{enabled_scene_5}",
+              "enabled_scene_6": "{enabled_scene_6}",
+              "enabled_scene_7": "{enabled_scene_7}",
+              "enabled_scene_8": "{enabled_scene_8}",
+              "enabled_scene_9": "{enabled_scene_9}",
+              "enabled_scene_10": "{enabled_scene_10}",
+              "enabled_scene_11": "{enabled_scene_11}",
+              "enabled_scene_12": "{enabled_scene_12}",
+              "enabled_scene_13": "{enabled_scene_13}",
+              "enabled_scene_14": "{enabled_scene_14}",
+              "enabled_scene_15": "{enabled_scene_15}",
+              "enabled_scene_16": "{enabled_scene_16}",
+              "enabled_scene_17": "{enabled_scene_17}",
+              "enabled_scene_18": "{enabled_scene_18}",
+              "enabled_scene_19": "{enabled_scene_19}",
+              "enabled_scene_20": "{enabled_scene_20}",
+              "enabled_scene_21": "{enabled_scene_21}",
+              "enabled_scene_22": "{enabled_scene_22}",
+              "enabled_scene_23": "{enabled_scene_23}",
+              "enabled_scene_24": "{enabled_scene_24}",
+              "enabled_scene_25": "{enabled_scene_25}",
+              "enabled_scene_26": "{enabled_scene_26}",
+              "enabled_scene_27": "{enabled_scene_27}",
+              "enabled_scene_28": "{enabled_scene_28}",
+              "enabled_scene_29": "{enabled_scene_29}",
+              "enabled_scene_30": "{enabled_scene_30}",
+              "enabled_scene_31": "{enabled_scene_31}",
+              "enabled_scene_32": "{enabled_scene_32}",
+              "enabled_scene_33": "{enabled_scene_33}",
+              "enabled_scene_34": "{enabled_scene_34}",
+              "enabled_scene_35": "{enabled_scene_35}",
+              "enabled_scene_36": "{enabled_scene_36}",
+              "enabled_scene_37": "{enabled_scene_37}",
+              "enabled_scene_38": "{enabled_scene_38}",
+              "enabled_scene_39": "{enabled_scene_39}",
+              "enabled_scene_40": "{enabled_scene_40}",
+              "enabled_scene_41": "{enabled_scene_41}",
+              "enabled_scene_42": "{enabled_scene_42}",
+              "enabled_scene_43": "{enabled_scene_43}",
+              "enabled_scene_44": "{enabled_scene_44}",
+              "enabled_scene_45": "{enabled_scene_45}",
+              "enabled_scene_46": "{enabled_scene_46}",
+              "enabled_scene_47": "{enabled_scene_47}",
+              "enabled_scene_48": "{enabled_scene_48}",
+              "enabled_scene_49": "{enabled_scene_49}"
+            },
+            "sections": {
+              "scene_section_0": {"name": "Hardcoded Test Title",
+                "description": "Scene {scene_0} is a {scene_type} scene."
+              }
             }
           }
         },

--- a/custom_components/tewke/translations/en.json
+++ b/custom_components/tewke/translations/en.json
@@ -1,164 +1,110 @@
 {
-  "config": {
-    "abort": {
-      "already_configured": "Device is already configured.",
-      "cannot_identify": "Unable to determine a unique ID for this device. Please check your device and network configuration.",
-      "no_devices_found": "No devices found on the network.",
-      "single_instance_allowed": "Already configured. Only a single configuration possible."
-    },
-    "step": {
-      "zeroconf_confirm": {
-        "description": "You are setting up the Tewke device **{name}**{room_suffix}. Click Submit to continue.",
-        "title": "Tewke device found"
-      },
-      "confirm_control_types": {
-        "description": "Choose the Home Assistant platform type for each scene, and optionally mark scenes to start disabled.\n\n**Light** (default) \u2014 the scene appears as a dimmable light entity.\n**Switch** \u2014 use this if you want to remove brightness control entirely.\n**Fan** \u2014 use this if you want brightness or speed control, but do not want the scene to appear as a light entity.",
-        "title": "Configure scene types"
-      },
-      "fan_default_speeds": {
-        "description": "Set the default scene value (1\u2013100) to be applied when each scene is turned on without a specific value.",
-        "title": "Default scene dimming"
-      },
-      "confirmation": {
-        "description": "Your Tewke device **{name}** is ready to be added to Home Assistant. Click Submit to complete the setup.",
-        "title": "Final setup"
-      }
-    }
-  },
-  "options": {
-    "abort": {
-      "no_fan_scenes": "No fan scenes are configured for this device."
-    },
-    "step": {
-      "init": {
-        "description": "Set the default scene value (1\u2013100) to be applied when each scene is turned on without a specific value.",
-        "title": "Default scene dimming"
-      }
-    }
-  },
-  "issues": {
-    "new_scenes_found": {
-      "title": "New Scenes discovered",
-      "description": "New Scenes have been discovered on your Tewke device {name}.\n\nPlease configure them to make them available in Home Assistant.",
-      "fix_flow": {
-        "step": {
-          "configure_scenes": {
-            "title": "Configure new scenes for {name}",
-            "description": "New scenes were found on your Tewke device **{name}**. Assign a Home Assistant platform type to each one below.",
-            "data": {
-              "scene_section_0": "{scene_0}",
-              "scene_0": "{scene_0}",
-              "scene_1": "{scene_1}",
-              "scene_2": "{scene_2}",
-              "scene_3": "{scene_3}",
-              "scene_4": "{scene_4}",
-              "scene_5": "{scene_5}",
-              "scene_6": "{scene_6}",
-              "scene_7": "{scene_7}",
-              "scene_8": "{scene_8}",
-              "scene_9": "{scene_9}",
-              "scene_10": "{scene_10}",
-              "scene_11": "{scene_11}",
-              "scene_12": "{scene_12}",
-              "scene_13": "{scene_13}",
-              "scene_14": "{scene_14}",
-              "scene_15": "{scene_15}",
-              "scene_16": "{scene_16}",
-              "scene_17": "{scene_17}",
-              "scene_18": "{scene_18}",
-              "scene_19": "{scene_19}",
-              "scene_20": "{scene_20}",
-              "scene_21": "{scene_21}",
-              "scene_22": "{scene_22}",
-              "scene_23": "{scene_23}",
-              "scene_24": "{scene_24}",
-              "scene_25": "{scene_25}",
-              "scene_26": "{scene_26}",
-              "scene_27": "{scene_27}",
-              "scene_28": "{scene_28}",
-              "scene_29": "{scene_29}",
-              "scene_30": "{scene_30}",
-              "scene_31": "{scene_31}",
-              "scene_32": "{scene_32}",
-              "scene_33": "{scene_33}",
-              "scene_34": "{scene_34}",
-              "scene_35": "{scene_35}",
-              "scene_36": "{scene_36}",
-              "scene_37": "{scene_37}",
-              "scene_38": "{scene_38}",
-              "scene_39": "{scene_39}",
-              "scene_40": "{scene_40}",
-              "scene_41": "{scene_41}",
-              "scene_42": "{scene_42}",
-              "scene_43": "{scene_43}",
-              "scene_44": "{scene_44}",
-              "scene_45": "{scene_45}",
-              "scene_46": "{scene_46}",
-              "scene_47": "{scene_47}",
-              "scene_48": "{scene_48}",
-              "scene_49": "{scene_49}",
-              "enabled_scene_0": "{enabled_scene_0}",
-              "enabled_scene_1": "{enabled_scene_1}",
-              "enabled_scene_2": "{enabled_scene_2}",
-              "enabled_scene_3": "{enabled_scene_3}",
-              "enabled_scene_4": "{enabled_scene_4}",
-              "enabled_scene_5": "{enabled_scene_5}",
-              "enabled_scene_6": "{enabled_scene_6}",
-              "enabled_scene_7": "{enabled_scene_7}",
-              "enabled_scene_8": "{enabled_scene_8}",
-              "enabled_scene_9": "{enabled_scene_9}",
-              "enabled_scene_10": "{enabled_scene_10}",
-              "enabled_scene_11": "{enabled_scene_11}",
-              "enabled_scene_12": "{enabled_scene_12}",
-              "enabled_scene_13": "{enabled_scene_13}",
-              "enabled_scene_14": "{enabled_scene_14}",
-              "enabled_scene_15": "{enabled_scene_15}",
-              "enabled_scene_16": "{enabled_scene_16}",
-              "enabled_scene_17": "{enabled_scene_17}",
-              "enabled_scene_18": "{enabled_scene_18}",
-              "enabled_scene_19": "{enabled_scene_19}",
-              "enabled_scene_20": "{enabled_scene_20}",
-              "enabled_scene_21": "{enabled_scene_21}",
-              "enabled_scene_22": "{enabled_scene_22}",
-              "enabled_scene_23": "{enabled_scene_23}",
-              "enabled_scene_24": "{enabled_scene_24}",
-              "enabled_scene_25": "{enabled_scene_25}",
-              "enabled_scene_26": "{enabled_scene_26}",
-              "enabled_scene_27": "{enabled_scene_27}",
-              "enabled_scene_28": "{enabled_scene_28}",
-              "enabled_scene_29": "{enabled_scene_29}",
-              "enabled_scene_30": "{enabled_scene_30}",
-              "enabled_scene_31": "{enabled_scene_31}",
-              "enabled_scene_32": "{enabled_scene_32}",
-              "enabled_scene_33": "{enabled_scene_33}",
-              "enabled_scene_34": "{enabled_scene_34}",
-              "enabled_scene_35": "{enabled_scene_35}",
-              "enabled_scene_36": "{enabled_scene_36}",
-              "enabled_scene_37": "{enabled_scene_37}",
-              "enabled_scene_38": "{enabled_scene_38}",
-              "enabled_scene_39": "{enabled_scene_39}",
-              "enabled_scene_40": "{enabled_scene_40}",
-              "enabled_scene_41": "{enabled_scene_41}",
-              "enabled_scene_42": "{enabled_scene_42}",
-              "enabled_scene_43": "{enabled_scene_43}",
-              "enabled_scene_44": "{enabled_scene_44}",
-              "enabled_scene_45": "{enabled_scene_45}",
-              "enabled_scene_46": "{enabled_scene_46}",
-              "enabled_scene_47": "{enabled_scene_47}",
-              "enabled_scene_48": "{enabled_scene_48}",
-              "enabled_scene_49": "{enabled_scene_49}"
-            },
-            "sections": {
-              "scene_section_0": {"name": "Hardcoded Test Title",
-                "description": "Scene {scene_0} is a {scene_type} scene."
-              }
-            }
-          }
-        },
-        "abort": {
-          "no_new_scenes": "There are no new scenes pending configuration for your Tewke device {name}."
-        }
-      }
-    }
-  }
+	"config": {
+		"abort": {
+			"already_configured": "Device is already configured.",
+			"cannot_identify": "Unable to determine a unique ID for this device. Please check your device and network configuration.",
+			"no_devices_found": "No devices found on the network.",
+			"single_instance_allowed": "Already configured. Only a single configuration possible."
+		},
+		"step": {
+			"zeroconf_confirm": {
+				"description": "You are setting up the Tewke device **{name}**{room_suffix}. Click Submit to continue.",
+				"title": "Tewke device found"
+			},
+			"confirm_control_types": {
+				"description": "Choose the Home Assistant platform type for each scene, and optionally mark scenes to start disabled.\n\n**Light** (default) \u2014 the scene appears as a dimmable light entity.\n**Switch** \u2014 use this if you want to remove brightness control entirely.\n**Fan** \u2014 use this if you want brightness or speed control, but do not want the scene to appear as a light entity.",
+				"title": "Configure scene types"
+			},
+			"fan_default_speeds": {
+				"description": "Set the default scene value (1\u2013100) to be applied when each scene is turned on without a specific value.",
+				"title": "Default scene dimming"
+			},
+			"confirmation": {
+				"description": "Your Tewke device **{name}** is ready to be added to Home Assistant. Click Submit to complete the setup.",
+				"title": "Final setup"
+			}
+		}
+	},
+	"options": {
+		"abort": {
+			"no_fan_scenes": "No fan scenes are configured for this device."
+		},
+		"step": {
+			"init": {
+				"description": "Set the default scene value (1\u2013100) to be applied when each scene is turned on without a specific value.",
+				"title": "Default scene dimming"
+			}
+		}
+	},
+	"issues": {
+		"new_scenes_found": {
+			"title": "New Scenes discovered",
+			"description": "New Scenes have been discovered on your Tewke device {name}.\n\nPlease configure them to make them available in Home Assistant.",
+			"fix_flow": {
+				"step": {
+					"configure_scenes": {
+						"title": "Configure new scenes for {name}",
+						"description": "New scenes were found on your Tewke device **{name}**. Assign a Home Assistant platform type to each one below.",
+						"data": {
+							"scene_text": "Control type",
+							"enabled_text": "Enabled",
+							"scene_section_0": "{scene_section_0}",
+							"scene_section_1": "{scene_section_1}",
+							"scene_section_2": "{scene_section_2}",
+							"scene_section_3": "{scene_section_3}",
+							"scene_section_4": "{scene_section_4}",
+							"scene_section_5": "{scene_section_5}",
+							"scene_section_6": "{scene_section_6}",
+							"scene_section_7": "{scene_section_7}",
+							"scene_section_8": "{scene_section_8}",
+							"scene_section_9": "{scene_section_9}",
+							"scene_section_10": "{scene_section_10}",
+							"scene_section_11": "{scene_section_11}",
+							"scene_section_12": "{scene_section_12}",
+							"scene_section_13": "{scene_section_13}",
+							"scene_section_14": "{scene_section_14}",
+							"scene_section_15": "{scene_section_15}",
+							"scene_section_16": "{scene_section_16}",
+							"scene_section_17": "{scene_section_17}",
+							"scene_section_18": "{scene_section_18}",
+							"scene_section_19": "{scene_section_19}",
+							"scene_section_20": "{scene_section_20}",
+							"scene_section_21": "{scene_section_21}",
+							"scene_section_22": "{scene_section_22}",
+							"scene_section_23": "{scene_section_23}",
+							"scene_section_24": "{scene_section_24}",
+							"scene_section_25": "{scene_section_25}",
+							"scene_section_26": "{scene_section_26}",
+							"scene_section_27": "{scene_section_27}",
+							"scene_section_28": "{scene_section_28}",
+							"scene_section_29": "{scene_section_29}",
+							"scene_section_30": "{scene_section_30}",
+							"scene_section_31": "{scene_section_31}",
+							"scene_section_32": "{scene_section_32}",
+							"scene_section_33": "{scene_section_33}",
+							"scene_section_34": "{scene_section_34}",
+							"scene_section_35": "{scene_section_35}",
+							"scene_section_36": "{scene_section_36}",
+							"scene_section_37": "{scene_section_37}",
+							"scene_section_38": "{scene_section_38}",
+							"scene_section_39": "{scene_section_39}",
+							"scene_section_40": "{scene_section_40}",
+							"scene_section_41": "{scene_section_41}",
+							"scene_section_42": "{scene_section_42}",
+							"scene_section_43": "{scene_section_43}",
+							"scene_section_44": "{scene_section_44}",
+							"scene_section_45": "{scene_section_45}",
+							"scene_section_46": "{scene_section_46}",
+							"scene_section_47": "{scene_section_47}",
+							"scene_section_48": "{scene_section_48}",
+							"scene_section_49": "{scene_section_49}"
+						}
+					}
+				},
+				"abort": {
+					"no_new_scenes": "There are no new scenes pending configuration for your Tewke device {name}."
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Adds sections to our display UI, and disabled scene functionality


New device | Repair scenes 
--- | ---
<img width="698" height="1195" alt="image" src="https://github.com/user-attachments/assets/07fb2401-feff-4e59-998f-09768a774be7" /> | <img width="606" height="762" alt="image" src="https://github.com/user-attachments/assets/fa58c4dd-831d-4577-af74-fa964562f35a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Individual scenes can now be disabled during initial configuration so they won’t be created as active entities.
  * Per-scene enable/disable controls added to configuration and repair UIs for granular management.
  * Disabled scenes persist across updates and are respected for both existing and newly discovered scenes; labels and prompts updated to reflect the new option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->