### PR TITLE
feat: Prioritize wall dock ID for stable device identifiers

### DIFF
--- a/custom_components/tewke/__init__.py
+++ b/custom_components/tewke/__init__.py
@@ -203,8 +203,9 @@ async def async_setup_entry(
                 data={**entry.data, CONF_NAME: new_name},
             )
             device_registry = dr.async_get(hass)
+            device_id = tap.wall_dock_id or entry.unique_id or entry.entry_id
             device = device_registry.async_get_device(
-                identifiers={(DOMAIN, entry.unique_id or entry.entry_id)}
+                identifiers={(DOMAIN, device_id)}
             )
             if device:
                 device_registry.async_update_device(device.id, name=new_name)

--- a/custom_components/tewke/entity.py
+++ b/custom_components/tewke/entity.py
@@ -26,9 +26,12 @@ class TewkeEntity(CoordinatorEntity[TewkeCoordinator]):
         super().__init__(coordinator)
         entry = coordinator.config_entry
         tap = entry.runtime_data.tap
-        device_id = tap.wall_dock_id or entry.unique_id or entry.entry_id
+        legacy_id = entry.unique_id or entry.entry_id
+        identifiers: set[tuple[str, str]] = {(DOMAIN, legacy_id)}
+        if tap.wall_dock_id:
+            identifiers.add((DOMAIN, tap.wall_dock_id))
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device_id)},
+            identifiers=identifiers,
             name=entry.data.get(CONF_NAME, "Tewke"),
             manufacturer="Tewke",
             model="Tap",

--- a/custom_components/tewke/entity.py
+++ b/custom_components/tewke/entity.py
@@ -26,8 +26,9 @@ class TewkeEntity(CoordinatorEntity[TewkeCoordinator]):
         super().__init__(coordinator)
         entry = coordinator.config_entry
         tap = entry.runtime_data.tap
+        device_id = tap.wall_dock_id or entry.unique_id or entry.entry_id
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.unique_id or entry.entry_id)},
+            identifiers={(DOMAIN, device_id)},
             name=entry.data.get(CONF_NAME, "Tewke"),
             manufacturer="Tewke",
             model="Tap",


### PR DESCRIPTION
The `wall_dock_id` offers a consistent, hardware-specific identifier for Tewke devices. By prioritizing its use, this change ensures that devices retain their identity within Home Assistant even if other identifiers, such as the `unique_id` or `entry_id`, change. This prevents devices from appearing as new and potentially losing their history or associated automations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device identification so devices are consistently recognized across the system.
  * Enhanced device rename handling to correctly locate and update the right device when identifiers are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->