### PR TITLE
feat: Use hardware IDs as sole identifiers for devices and entities

### DIFF
--- a/custom_components/tewke/__init__.py
+++ b/custom_components/tewke/__init__.py
@@ -203,10 +203,8 @@ async def async_setup_entry(
                 data={**entry.data, CONF_NAME: new_name},
             )
             device_registry = dr.async_get(hass)
-            device_id = tap.wall_dock_id or entry.unique_id or entry.entry_id
-            device = device_registry.async_get_device(
-                identifiers={(DOMAIN, device_id)}
-            )
+            device_id = tap.wall_dock_id
+            device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
             if device:
                 device_registry.async_update_device(device.id, name=new_name)
 

--- a/custom_components/tewke/binary_sensor.py
+++ b/custom_components/tewke/binary_sensor.py
@@ -86,10 +86,8 @@ class TewkeBinarySensor(TewkeEntity, BinarySensorEntity):
         """Initialise the binary sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        entry = coordinator.config_entry
-        self._attr_unique_id = (
-            f"{entry.unique_id or entry.entry_id}_sensor_{description.key}"
-        )
+        hardware_id = coordinator.data["config"].hardware_id
+        self._attr_unique_id = f"{hardware_id}_sensor_{description.key}"
 
     @property
     def is_on(self) -> bool | None:
@@ -109,8 +107,8 @@ class TewkeScreenBinarySensor(TewkeEntity, BinarySensorEntity):
     def __init__(self, coordinator: TewkeCoordinator) -> None:
         """Initialise the screen sensor."""
         super().__init__(coordinator)
-        entry = coordinator.config_entry
-        self._attr_unique_id = f"{entry.unique_id or entry.entry_id}_screen_on"
+        hardware_id = coordinator.data["config"].hardware_id
+        self._attr_unique_id = f"{hardware_id}_screen_on"
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/tewke/entity.py
+++ b/custom_components/tewke/entity.py
@@ -26,12 +26,12 @@ class TewkeEntity(CoordinatorEntity[TewkeCoordinator]):
         super().__init__(coordinator)
         entry = coordinator.config_entry
         tap = entry.runtime_data.tap
-        legacy_id = entry.unique_id or entry.entry_id
-        identifiers: set[tuple[str, str]] = {(DOMAIN, legacy_id)}
-        if tap.wall_dock_id:
-            identifiers.add((DOMAIN, tap.wall_dock_id))
+        wall_dock_id = tap.wall_dock_id
+        if wall_dock_id is None:
+            msg = "Tewke device missing wall_dock_id"
+            raise ValueError(msg)  # noqa: TRY003
         self._attr_device_info = DeviceInfo(
-            identifiers=identifiers,
+            identifiers={(DOMAIN, wall_dock_id)},
             name=entry.data.get(CONF_NAME, "Tewke"),
             manufacturer="Tewke",
             model="Tap",

--- a/custom_components/tewke/scene.py
+++ b/custom_components/tewke/scene.py
@@ -51,8 +51,8 @@ class TewkeSceneEntity(TewkeEntity):
         super().__init__(coordinator)
         self._scene_id = scene.id
         self._attr_name = scene.name
-        entry = coordinator.config_entry
-        self._attr_unique_id = f"{entry.unique_id or entry.entry_id}_{scene.id}"
+        hardware_id = coordinator.data["config"].hardware_id
+        self._attr_unique_id = f"{hardware_id}_{scene.id}"
         self._is_on = scene.is_active
         self._brightness: int | None = scene.brightness
         self._attr_entity_registry_enabled_default = enabled_default

--- a/custom_components/tewke/sensor.py
+++ b/custom_components/tewke/sensor.py
@@ -198,10 +198,8 @@ class TewkeSensor(TewkeEntity, SensorEntity):
         """Initialise the sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        entry = coordinator.config_entry
-        self._attr_unique_id = (
-            f"{entry.unique_id or entry.entry_id}_sensor_{description.key}"
-        )
+        hardware_id = coordinator.data["config"].hardware_id
+        self._attr_unique_id = f"{hardware_id}_sensor_{description.key}"
 
     @property
     def native_value(self) -> float | int | None:
@@ -271,8 +269,8 @@ class TewkeRadarSensor(TewkeEntity, SensorEntity):
         """Initialise the radar sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        entry = coordinator.config_entry
-        self._attr_unique_id = f"{entry.unique_id or entry.entry_id}_{description.key}"
+        hardware_id = coordinator.data["config"].hardware_id
+        self._attr_unique_id = f"{hardware_id}_{description.key}"
 
     @property
     def native_value(self) -> str | int | None:
@@ -326,8 +324,8 @@ class TewkeEnergySensor(TewkeEntity, SensorEntity):
         """Initialise the energy sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        entry = coordinator.config_entry
-        self._attr_unique_id = f"{entry.unique_id or entry.entry_id}_{description.key}"
+        hardware_id = coordinator.data["config"].hardware_id
+        self._attr_unique_id = f"{hardware_id}_{description.key}"
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/tewke/target.py
+++ b/custom_components/tewke/target.py
@@ -48,10 +48,8 @@ class TewkeTargetLight(TewkeEntity, LightEntity):
         super().__init__(coordinator)
         self._target_index = target.index
         self._attr_name = target.name
-        entry = coordinator.config_entry
-        self._attr_unique_id = (
-            f"{entry.unique_id or entry.entry_id}_target_{target.index}"
-        )
+        hardware_id = coordinator.data["config"].hardware_id
+        self._attr_unique_id = f"{hardware_id}_target_{target.index}"
         if target.is_dimmable:
             self._attr_color_mode = ColorMode.BRIGHTNESS
             self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}


### PR DESCRIPTION
Removes reliance on `unique_id` or `entry_id` fallbacks for device and entity identification. This ensures that `wall_dock_id` for devices and `hardware_id` for entities are the exclusive identifiers.

This guarantees stable and persistent identification within Home Assistant, preventing devices or entities from appearing as new if configuration entry IDs change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated entity unique identification to use hardware-based identifiers instead of configuration entry identifiers across all entity types (sensors, binary sensors, lights, and scenes).
  * Streamlined device registry lookup mechanism for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->