### PR TITLE
refactor: move observe setup to util and add recovery in coordinator

### DIFF
--- a/custom_components/tewke/__init__.py
+++ b/custom_components/tewke/__init__.py
@@ -5,31 +5,17 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytewke
-from homeassistant.const import CONF_HOST, CONF_NAME, Platform
+from homeassistant.const import CONF_HOST, Platform
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers import issue_registry as ir
 from pytewke.error import PyTewkeDiscoveryError
 
-from .const import (
-    CONF_DEFAULT_SCENE_FAN_DIMMING,
-    CONF_DISABLED_SCENES,
-    DOMAIN,
-    LOGGER,
-)
+from .const import DOMAIN, LOGGER
 from .coordinator import TewkeCoordinator
 from .data import TewkeData
+from .util import async_setup_observe
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
-    from pytewke.data import (
-        ConfigData,
-        EnergyData,
-        RadarData,
-        Scene,
-        SensorData,
-        Target,
-    )
 
     from .data import TewkeConfigEntry
 
@@ -42,7 +28,7 @@ PLATFORMS: list[Platform] = [
 ]
 
 
-async def async_setup_entry(  # noqa: PLR0915
+async def async_setup_entry(
     hass: HomeAssistant,
     entry: TewkeConfigEntry,
 ) -> bool:
@@ -72,187 +58,7 @@ async def async_setup_entry(  # noqa: PLR0915
 
     await tewke_coordinator.async_config_entry_first_refresh()
 
-    def _on_scene_update(scenes: dict[str, Scene]) -> None:
-        """
-        Handle scene updates from the Tewke device.
-
-        This callback is triggered when the scenes on the device change. It
-        identifies new scenes and creates a repair issue to configure them.
-        """
-        if tewke_coordinator.data is None:
-            return
-
-        scene_control_types = entry.runtime_data.scene_control_types
-
-        # Handle scenes that are no longer provided by the device
-        removed_configured_ids = [
-            sid for sid in scene_control_types if sid not in scenes
-        ]
-        if removed_configured_ids:
-            LOGGER.info(
-                "Marking deleted scenes as unavailable: %s", removed_configured_ids
-            )
-            new_scene_control_types = dict(scene_control_types)
-
-            for sid in removed_configured_ids:
-                del new_scene_control_types[sid]
-
-            new_data = dict(entry.data)
-            new_data["scene_control_types"] = new_scene_control_types
-
-            if CONF_DISABLED_SCENES in new_data:
-                new_data[CONF_DISABLED_SCENES] = [
-                    sid
-                    for sid in new_data[CONF_DISABLED_SCENES]
-                    if sid not in removed_configured_ids
-                ]
-            if CONF_DEFAULT_SCENE_FAN_DIMMING in new_data:
-                new_fan_dimming = dict(new_data[CONF_DEFAULT_SCENE_FAN_DIMMING])
-                for sid in removed_configured_ids:
-                    new_fan_dimming.pop(sid, None)
-                new_data[CONF_DEFAULT_SCENE_FAN_DIMMING] = new_fan_dimming
-
-            entry.runtime_data.scene_control_types = new_scene_control_types
-            hass.config_entries.async_update_entry(entry, data=new_data)
-            return
-
-        configured_scenes = {
-            scene_id: scene
-            for scene_id, scene in scenes.items()
-            if scene_id in scene_control_types
-        }
-
-        tewke_coordinator.async_set_updated_data(
-            {
-                **tewke_coordinator.data,
-                "scenes": configured_scenes,
-                "scenes_all": scenes,
-            }
-        )
-
-        # Remove pending scenes that no longer exist on the device
-        stale_ids = [
-            sid for sid in entry.runtime_data.pending_scenes if sid not in scenes
-        ]
-        for sid in stale_ids:
-            del entry.runtime_data.pending_scenes[sid]
-
-        new_scenes = {
-            scene_id: scene
-            for scene_id, scene in scenes.items()
-            if scene_id not in scene_control_types
-            and scene_id not in entry.runtime_data.pending_scenes
-        }
-
-        if not new_scenes and not entry.runtime_data.pending_scenes:
-            ir.async_delete_issue(hass, DOMAIN, f"new_scenes_found_{entry.entry_id}")
-
-        if new_scenes:
-            LOGGER.info("Discovered new scenes, pending configuration: %s", new_scenes)
-            entry.runtime_data.pending_scenes.update(new_scenes)
-            ir.async_create_issue(
-                hass,
-                DOMAIN,
-                f"new_scenes_found_{entry.entry_id}",
-                data={"entry_id": entry.entry_id},
-                is_fixable=True,
-                is_persistent=False,
-                severity=ir.IssueSeverity.WARNING,
-                translation_key="new_scenes_found",
-                translation_placeholders={"name": entry.title},
-            )
-
-    # Process initial scenes found during discovery (using scenes_all)
-    if tewke_coordinator.data and "scenes_all" in tewke_coordinator.data:
-        _on_scene_update(tewke_coordinator.data["scenes_all"])
-
-    def _on_target_update(targets: dict[int, Target]) -> None:
-        """
-        Handle target updates from the Tewke device.
-
-        This callback is triggered when the targets on the device change.
-        It updates the coordinator with the new target data.
-        """
-        if tewke_coordinator.data is None:
-            return
-
-        tewke_coordinator.async_set_updated_data(
-            {
-                **tewke_coordinator.data,
-                "targets": targets,
-            }
-        )
-
-    def _on_sensor_update(sensor_data: SensorData) -> None:
-        """
-        Handle sensor updates from the Tewke device.
-
-        This callback is triggered when the sensors on the device change.
-        """
-        if tewke_coordinator.data is None:
-            return
-        tewke_coordinator.async_set_updated_data(
-            {**tewke_coordinator.data, "sensors": sensor_data}
-        )
-
-    def _on_radar_update(radar_data: RadarData) -> None:
-        """
-        Handle radar updates from the Tewke device.
-
-        This callback is triggered when the radar on the device changes.
-        """
-        if tewke_coordinator.data is None:
-            return
-        tewke_coordinator.async_set_updated_data(
-            {**tewke_coordinator.data, "radar": radar_data}
-        )
-
-    def _on_energy_update(energy_data: EnergyData) -> None:
-        """
-        Handle energy updates from the Tewke device.
-
-        This callback is triggered when the energy on the device changes.
-        """
-        if tewke_coordinator.data is None:
-            return
-        tewke_coordinator.async_set_updated_data(
-            {**tewke_coordinator.data, "energy": energy_data}
-        )
-
-    def _on_config_update(config_data: ConfigData) -> None:
-        """
-        Handle config updates from the Tewke device.
-
-        This callback is triggered when the config on the device changes.
-        """
-        if tewke_coordinator.data is None:
-            return
-        tewke_coordinator.async_set_updated_data(
-            {**tewke_coordinator.data, "config": config_data}
-        )
-
-        new_name = config_data.device_name
-        if new_name and new_name != entry.data.get(CONF_NAME):
-            LOGGER.debug("Device renamed to %r, updating HA", new_name)
-            hass.config_entries.async_update_entry(
-                entry,
-                title=new_name,
-                data={**entry.data, CONF_NAME: new_name},
-            )
-            device_registry = dr.async_get(hass)
-            device_id = tap.wall_dock_id
-            device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
-            if device:
-                device_registry.async_update_device(device.id, name=new_name)
-
-    await tap.observe(
-        scene_callback=_on_scene_update,
-        target_callback=_on_target_update,
-        sensor_callback=_on_sensor_update,
-        radar_callback=_on_radar_update,
-        energy_callback=_on_energy_update,
-        config_change_callback=_on_config_update,
-    )
+    await async_setup_observe(hass, entry, tewke_coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))

--- a/custom_components/tewke/__init__.py
+++ b/custom_components/tewke/__init__.py
@@ -12,7 +12,6 @@ from pytewke.error import PyTewkeDiscoveryError
 from .const import DOMAIN, LOGGER
 from .coordinator import TewkeCoordinator
 from .data import TewkeData
-from .util import async_setup_observe
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant

--- a/custom_components/tewke/__init__.py
+++ b/custom_components/tewke/__init__.py
@@ -58,8 +58,6 @@ async def async_setup_entry(
 
     await tewke_coordinator.async_config_entry_first_refresh()
 
-    await async_setup_observe(hass, entry, tewke_coordinator)
-
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     entry.async_on_unload(tap.close)

--- a/custom_components/tewke/coordinator.py
+++ b/custom_components/tewke/coordinator.py
@@ -114,6 +114,23 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
             update_interval=_RECOVERY_INTERVAL,
         )
 
+    async def _setup_observe(self) -> None:
+        def handle_timeout() -> None:
+            self.config_entry.runtime_data.observe_active = False
+            self.hass.async_create_task(self._setup_observe())
+
+        if not self.config_entry.runtime_data.observe_active:
+            LOGGER.info(
+                "CoAP observations not active for %s; attempting to re-establish",
+                self.config_entry.entry_id,
+            )
+            await async_setup_observe(
+                self,
+                self.hass,
+                self.config_entry,
+                timeout_callback=handle_timeout,
+            )
+
     async def _async_update_data(self) -> TewkeCoordinatorData:
         """Fetch current state for all resources, retrying on transient errors."""
         tap = self.config_entry.runtime_data.tap
@@ -128,13 +145,6 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
         ) as err:
             msg = f"Error communicating with Tewke Tap: {err}"
             raise UpdateFailed(msg) from err
-
-        if not self.config_entry.runtime_data.observe_active:
-            LOGGER.info(
-                "CoAP observations not active for %s; attempting to re-establish",
-                self.config_entry.entry_id,
-            )
-            await async_setup_observe(self.hass, self.config_entry, self)
 
         scene_control_types = self.config_entry.runtime_data.scene_control_types
         configured_scenes = {

--- a/custom_components/tewke/coordinator.py
+++ b/custom_components/tewke/coordinator.py
@@ -113,13 +113,31 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
             name=name,
             update_interval=_RECOVERY_INTERVAL,
         )
+        self._observe_setup_lock = asyncio.Lock()
+        self._observe_retry_task: asyncio.Task[None] | None = None
 
     async def _setup_observe(self) -> None:
+        async def retry_setup_observe() -> None:
+            try:
+                await self._setup_observe()
+            finally:
+                if self._observe_retry_task is asyncio.current_task():
+                    self._observe_retry_task = None
+
         def handle_timeout() -> None:
             self.config_entry.runtime_data.observe_active = False
-            self.hass.async_create_task(self._setup_observe())
+            if (
+                self._observe_retry_task is not None
+                and not self._observe_retry_task.done()
+            ):
+                return
+            self._observe_retry_task = self.hass.async_create_task(
+                retry_setup_observe()
+            )
 
-        if not self.config_entry.runtime_data.observe_active:
+        async with self._observe_setup_lock:
+            if self.config_entry.runtime_data.observe_active:
+                return
             LOGGER.info(
                 "CoAP observations not active for %s; attempting to re-establish",
                 self.config_entry.entry_id,
@@ -133,7 +151,10 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
 
     async def _async_update_data(self) -> TewkeCoordinatorData:
         """Fetch current state for all resources, retrying on transient errors."""
+        await self._setup_observe()
+
         tap = self.config_entry.runtime_data.tap
+
         try:
             scenes_all = await _fetch_with_retries(tap.get_scenes)
             targets = await _fetch_with_retries(tap.get_targets)

--- a/custom_components/tewke/coordinator.py
+++ b/custom_components/tewke/coordinator.py
@@ -14,6 +14,7 @@ from pytewke.error import (
 )
 
 from .const import LOGGER
+from .util import async_setup_observe
 
 if TYPE_CHECKING:
     import logging
@@ -127,6 +128,13 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
         ) as err:
             msg = f"Error communicating with Tewke Tap: {err}"
             raise UpdateFailed(msg) from err
+
+        if not self.config_entry.runtime_data.observe_active:
+            LOGGER.info(
+                "CoAP observations not active for %s; attempting to re-establish",
+                self.config_entry.entry_id,
+            )
+            await async_setup_observe(self.hass, self.config_entry, self)
 
         scene_control_types = self.config_entry.runtime_data.scene_control_types
         configured_scenes = {

--- a/custom_components/tewke/data.py
+++ b/custom_components/tewke/data.py
@@ -24,3 +24,4 @@ class TewkeData:
     coordinator: TewkeCoordinator
     scene_control_types: dict[str, str]
     pending_scenes: dict[str, Scene] = field(default_factory=dict)
+    observe_active: bool = False

--- a/custom_components/tewke/manifest.json
+++ b/custom_components/tewke/manifest.json
@@ -9,7 +9,7 @@
 	"loggers": ["pytewke"],
 	"quality_scale": "bronze",
 	"requirements": [
-		"git+https://gitlab.com/tewke/open-source/pytewke.git@2eb1a9ff094db69dd6cf5007431fc47e47977f58#pytewke"
+		"pytewke==0.5.0"
 	],
 	"zeroconf": [
 		{

--- a/custom_components/tewke/util.py
+++ b/custom_components/tewke/util.py
@@ -4,9 +4,30 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .const import CONF_DEFAULT_SCENE_FAN_DIMMING
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import issue_registry as ir
+from pytewke.error import PyTewkeObserveError
+
+from .const import (
+    CONF_DEFAULT_SCENE_FAN_DIMMING,
+    CONF_DISABLED_SCENES,
+    DOMAIN,
+    LOGGER,
+)
 
 if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from pytewke.data import (
+        ConfigData,
+        EnergyData,
+        RadarData,
+        Scene,
+        SensorData,
+        Target,
+    )
+
+    from .coordinator import TewkeCoordinator
     from .data import TewkeConfigEntry
 
 
@@ -35,3 +56,212 @@ def _ha_to_tewke_brightness(value: int) -> int:
     """
     value = max(0, min(255, value))
     return round(value / 255 * 100)
+
+
+async def async_setup_observe(
+    hass: HomeAssistant,
+    entry: TewkeConfigEntry,
+    coordinator: TewkeCoordinator,
+) -> bool:
+    """
+    Register CoAP observation callbacks on the Tap and start observing.
+
+    Returns True if observe was set up successfully, False otherwise.
+    The ``observe_active`` flag on ``entry.runtime_data`` is set accordingly.
+    """
+    tap = entry.runtime_data.tap
+
+    def _on_scene_update(scenes: dict[str, Scene]) -> None:
+        """
+        Handle scene updates from the Tewke device.
+
+        This callback is triggered when the scenes on the device change. It
+        identifies new scenes and creates a repair issue to configure them.
+        """
+        if coordinator.data is None:
+            return
+
+        scene_control_types = entry.runtime_data.scene_control_types
+
+        # Handle scenes that are no longer provided by the device
+        removed_configured_ids = [
+            sid for sid in scene_control_types if sid not in scenes
+        ]
+        if removed_configured_ids:
+            LOGGER.info(
+                "Marking deleted scenes as unavailable: %s", removed_configured_ids
+            )
+            new_scene_control_types = dict(scene_control_types)
+
+            for sid in removed_configured_ids:
+                del new_scene_control_types[sid]
+
+            new_data = dict(entry.data)
+            new_data["scene_control_types"] = new_scene_control_types
+
+            if CONF_DISABLED_SCENES in new_data:
+                new_data[CONF_DISABLED_SCENES] = [
+                    sid
+                    for sid in new_data[CONF_DISABLED_SCENES]
+                    if sid not in removed_configured_ids
+                ]
+            if CONF_DEFAULT_SCENE_FAN_DIMMING in new_data:
+                new_fan_dimming = dict(new_data[CONF_DEFAULT_SCENE_FAN_DIMMING])
+                for sid in removed_configured_ids:
+                    new_fan_dimming.pop(sid, None)
+                new_data[CONF_DEFAULT_SCENE_FAN_DIMMING] = new_fan_dimming
+
+            entry.runtime_data.scene_control_types = new_scene_control_types
+            hass.config_entries.async_update_entry(entry, data=new_data)
+            return
+
+        configured_scenes = {
+            scene_id: scene
+            for scene_id, scene in scenes.items()
+            if scene_id in scene_control_types
+        }
+
+        coordinator.async_set_updated_data(
+            {
+                **coordinator.data,
+                "scenes": configured_scenes,
+                "scenes_all": scenes,
+            }
+        )
+
+        # Remove pending scenes that no longer exist on the device
+        stale_ids = [
+            sid for sid in entry.runtime_data.pending_scenes if sid not in scenes
+        ]
+        for sid in stale_ids:
+            del entry.runtime_data.pending_scenes[sid]
+
+        new_scenes = {
+            scene_id: scene
+            for scene_id, scene in scenes.items()
+            if scene_id not in scene_control_types
+            and scene_id not in entry.runtime_data.pending_scenes
+        }
+
+        if not new_scenes and not entry.runtime_data.pending_scenes:
+            ir.async_delete_issue(hass, DOMAIN, f"new_scenes_found_{entry.entry_id}")
+
+        if new_scenes:
+            LOGGER.info("Discovered new scenes, pending configuration: %s", new_scenes)
+            entry.runtime_data.pending_scenes.update(new_scenes)
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                f"new_scenes_found_{entry.entry_id}",
+                data={"entry_id": entry.entry_id},
+                is_fixable=True,
+                is_persistent=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="new_scenes_found",
+                translation_placeholders={"name": entry.title},
+            )
+
+    def _on_target_update(targets: dict[int, Target]) -> None:
+        """
+        Handle target updates from the Tewke device.
+
+        This callback is triggered when the targets on the device change.
+        It updates the coordinator with the new target data.
+        """
+        if coordinator.data is None:
+            return
+
+        coordinator.async_set_updated_data(
+            {
+                **coordinator.data,
+                "targets": targets,
+            }
+        )
+
+    def _on_sensor_update(sensor_data: SensorData) -> None:
+        """
+        Handle sensor updates from the Tewke device.
+
+        This callback is triggered when the sensors on the device change.
+        """
+        if coordinator.data is None:
+            return
+        coordinator.async_set_updated_data(
+            {**coordinator.data, "sensors": sensor_data}
+        )
+
+    def _on_radar_update(radar_data: RadarData) -> None:
+        """
+        Handle radar updates from the Tewke device.
+
+        This callback is triggered when the radar on the device changes.
+        """
+        if coordinator.data is None:
+            return
+        coordinator.async_set_updated_data(
+            {**coordinator.data, "radar": radar_data}
+        )
+
+    def _on_energy_update(energy_data: EnergyData) -> None:
+        """
+        Handle energy updates from the Tewke device.
+
+        This callback is triggered when the energy on the device changes.
+        """
+        if coordinator.data is None:
+            return
+        coordinator.async_set_updated_data(
+            {**coordinator.data, "energy": energy_data}
+        )
+
+    def _on_config_update(config_data: ConfigData) -> None:
+        """
+        Handle config updates from the Tewke device.
+
+        This callback is triggered when the config on the device changes.
+        """
+        if coordinator.data is None:
+            return
+        coordinator.async_set_updated_data(
+            {**coordinator.data, "config": config_data}
+        )
+
+        new_name = config_data.device_name
+        if new_name and new_name != entry.data.get(CONF_NAME):
+            LOGGER.debug("Device renamed to %r, updating HA", new_name)
+            hass.config_entries.async_update_entry(
+                entry,
+                title=new_name,
+                data={**entry.data, CONF_NAME: new_name},
+            )
+            device_registry = dr.async_get(hass)
+            device_id = tap.wall_dock_id
+            device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+            if device:
+                device_registry.async_update_device(device.id, name=new_name)
+
+    try:
+        await tap.observe(
+            scene_callback=_on_scene_update,
+            target_callback=_on_target_update,
+            sensor_callback=_on_sensor_update,
+            radar_callback=_on_radar_update,
+            energy_callback=_on_energy_update,
+            config_change_callback=_on_config_update,
+        )
+    except PyTewkeObserveError:
+        LOGGER.warning(
+            "Failed to set up CoAP observations for %s; will retry on next poll",
+            entry.data.get(CONF_NAME, entry.entry_id),
+            exc_info=True,
+        )
+        entry.runtime_data.observe_active = False
+        return False
+
+    entry.runtime_data.observe_active = True
+
+    # Process scenes already fetched during initial discovery
+    if coordinator.data and "scenes_all" in coordinator.data:
+        _on_scene_update(coordinator.data["scenes_all"])
+
+    return True

--- a/custom_components/tewke/util.py
+++ b/custom_components/tewke/util.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers import device_registry as dr
@@ -59,9 +59,10 @@ def _ha_to_tewke_brightness(value: int) -> int:
 
 
 async def async_setup_observe(
+    coordinator: TewkeCoordinator,
     hass: HomeAssistant,
     entry: TewkeConfigEntry,
-    coordinator: TewkeCoordinator,
+    timeout_callback: Callable[[], None],
 ) -> bool:
     """
     Register CoAP observation callbacks on the Tap and start observing.
@@ -186,9 +187,7 @@ async def async_setup_observe(
         """
         if coordinator.data is None:
             return
-        coordinator.async_set_updated_data(
-            {**coordinator.data, "sensors": sensor_data}
-        )
+        coordinator.async_set_updated_data({**coordinator.data, "sensors": sensor_data})
 
     def _on_radar_update(radar_data: RadarData) -> None:
         """
@@ -198,9 +197,7 @@ async def async_setup_observe(
         """
         if coordinator.data is None:
             return
-        coordinator.async_set_updated_data(
-            {**coordinator.data, "radar": radar_data}
-        )
+        coordinator.async_set_updated_data({**coordinator.data, "radar": radar_data})
 
     def _on_energy_update(energy_data: EnergyData) -> None:
         """
@@ -210,9 +207,7 @@ async def async_setup_observe(
         """
         if coordinator.data is None:
             return
-        coordinator.async_set_updated_data(
-            {**coordinator.data, "energy": energy_data}
-        )
+        coordinator.async_set_updated_data({**coordinator.data, "energy": energy_data})
 
     def _on_config_update(config_data: ConfigData) -> None:
         """
@@ -222,9 +217,7 @@ async def async_setup_observe(
         """
         if coordinator.data is None:
             return
-        coordinator.async_set_updated_data(
-            {**coordinator.data, "config": config_data}
-        )
+        coordinator.async_set_updated_data({**coordinator.data, "config": config_data})
 
         new_name = config_data.device_name
         if new_name and new_name != entry.data.get(CONF_NAME):
@@ -248,6 +241,8 @@ async def async_setup_observe(
             radar_callback=_on_radar_update,
             energy_callback=_on_energy_update,
             config_change_callback=_on_config_update,
+            timeout_in_secs=30,
+            timeout_callback=timeout_callback,
         )
     except PyTewkeObserveError:
         LOGGER.warning(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.14.2"
 dependencies = [
     "colorlog==6.10.1",
     "homeassistant==2026.3.3",
-    "pytewke>=0.5.0",
+    "pytewke==0.5.0",
     "voluptuous>=0.15.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.14.2"
 dependencies = [
     "colorlog==6.10.1",
     "homeassistant==2026.3.3",
-    "pytewke>=0.4.1",
+    "pytewke>=0.5.0",
     "voluptuous>=0.15.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -943,7 +943,7 @@ dev = [
 requires-dist = [
     { name = "colorlog", specifier = "==6.10.1" },
     { name = "homeassistant", specifier = "==2026.3.3" },
-    { name = "pytewke", specifier = ">=0.4.1" },
+    { name = "pytewke", specifier = ">=0.5.0" },
     { name = "voluptuous", specifier = ">=0.15.2" },
 ]
 
@@ -1644,16 +1644,16 @@ sdist = { url = "https://files.pythonhosted.org/packages/08/64/a99f27d3b4347486c
 
 [[package]]
 name = "pytewke"
-version = "0.4.1"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiocoap" },
     { name = "cbor2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/7b/e050a545f18c08f69c8425032c2e554ff5ca0757ee09118da3130df4e235/pytewke-0.4.1.tar.gz", hash = "sha256:6a683c995ab15df5ae747449a0c36729f28753eae0a9287a6a6af9254c37400b", size = 26166254, upload-time = "2026-05-01T14:20:06.242Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/f1/4b5631bb092a0de2408bb54dba98f31d0e9d9cb27ef7ecdc09593142d7a6/pytewke-0.5.0.tar.gz", hash = "sha256:76f801b8a8556d2bebf90ebc260ecd7fae202765794b093474925f5a65b33322", size = 35464430, upload-time = "2026-05-08T10:36:25.375Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/51/9e2727c72ea41cc1ad487f2af9b30cf36f409bd2edfd253b2fa322c02c47/pytewke-0.4.1-py3-none-any.whl", hash = "sha256:1bccc5777955d6e1987296564977263a0b213a846538e23bd7aca9c112ef5797", size = 21433, upload-time = "2026-05-01T14:20:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ca/26bc92bdf3edff778fd53fcac655a794fbf568487d17749ab253b7048b04/pytewke-0.5.0-py3-none-any.whl", hash = "sha256:eae27be711e5819f510e23733e14b3c8a19da4555c6d90fa44a8ca3af36696ba", size = 23010, upload-time = "2026-05-08T10:36:23.508Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -943,7 +943,7 @@ dev = [
 requires-dist = [
     { name = "colorlog", specifier = "==6.10.1" },
     { name = "homeassistant", specifier = "==2026.3.3" },
-    { name = "pytewke", specifier = ">=0.5.0" },
+    { name = "pytewke", specifier = "==0.5.0" },
     { name = "voluptuous", specifier = ">=0.15.2" },
 ]
 


### PR DESCRIPTION
- Add async_setup_observe() to util.py with all CoAP observation callbacks (scenes, targets, sensors, radar, energy, config)
- async_setup_observe sets observe_active=True on success, False on PyTewkeObserveError (so the coordinator can retry)
- Also triggers initial scene processing for data already fetched during the first coordinator refresh
- Add observe_active: bool = False field to TewkeData
- __init__.py now calls async_setup_observe() instead of defining callbacks inline; removes the PLR0915 noqa suppressor
- coordinator._async_update_data checks observe_active and calls async_setup_observe to re-establish observations if they are down

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observations now re-establish automatically after interruptions and process discovered scenes upon reconnect.
  * New handling creates actionable warnings when newly discovered scenes require user configuration.

* **Bug Fixes**
  * Improved scene discovery reconciliation, removing stale scenes and pruning pending entries.
  * Device rename changes now reliably sync across the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->