### PR TITLE
fix: schedule observe retry task on event loop from timeout thread

### DIFF
--- a/custom_components/tewke/coordinator.py
+++ b/custom_components/tewke/coordinator.py
@@ -125,9 +125,8 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
                     self._observe_retry_task = None
 
         def handle_timeout() -> None:
-            self.config_entry.runtime_data.observe_active = False
-
             def _schedule() -> None:
+                self.config_entry.runtime_data.observe_active = False
                 if (
                     self._observe_retry_task is not None
                     and not self._observe_retry_task.done()

--- a/custom_components/tewke/coordinator.py
+++ b/custom_components/tewke/coordinator.py
@@ -126,14 +126,20 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
 
         def handle_timeout() -> None:
             self.config_entry.runtime_data.observe_active = False
-            if (
-                self._observe_retry_task is not None
-                and not self._observe_retry_task.done()
-            ):
-                return
-            self._observe_retry_task = self.hass.async_create_task(
-                retry_setup_observe()
-            )
+
+            def _schedule() -> None:
+                if (
+                    self._observe_retry_task is not None
+                    and not self._observe_retry_task.done()
+                ):
+                    return
+                self._observe_retry_task = self.hass.async_create_task(
+                    retry_setup_observe()
+                )
+
+            # handle_timeout is fired from a threading.Timer thread; schedule
+            # task creation back onto the event loop to keep it thread-safe.
+            self.hass.loop.call_soon_threadsafe(_schedule)
 
         async with self._observe_setup_lock:
             if self.config_entry.runtime_data.observe_active:


### PR DESCRIPTION
handle_timeout is invoked by pytewke's ResettableTimer which runs on a threading.Timer background thread. Calling hass.async_create_task directly from that thread is not thread-safe and raises a RuntimeError in HA's strict thread-safety checks.

Fix by using hass.loop.call_soon_threadsafe to marshal the task creation back onto the event loop, where async_create_task is safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thread-safety issue in timeout retry logic to ensure stable operation during network observation re-establishment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->