### PR TITLE
refactor: replace threading.Timer timeout with asyncio-native async_call_later

### DIFF
--- a/custom_components/tewke/__init__.py
+++ b/custom_components/tewke/__init__.py
@@ -59,6 +59,7 @@ async def async_setup_entry(
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+    entry.async_on_unload(tewke_coordinator.cancel_observation_timeout)
     entry.async_on_unload(tap.close)
 
     return True

--- a/custom_components/tewke/coordinator.py
+++ b/custom_components/tewke/coordinator.py
@@ -139,10 +139,17 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
         )
 
     def cancel_observation_timeout(self) -> None:
-        """Cancel the pending inactivity timer, e.g. on entry unload."""
+        """Cancel the pending inactivity timer and any in-flight retry task.
+
+        Called on entry unload to prevent the retry task from running against
+        stale runtime_data after the entry has been torn down.
+        """
         if self._observation_timeout_unsub is not None:
             self._observation_timeout_unsub()
             self._observation_timeout_unsub = None
+        if self._observe_retry_task is not None and not self._observe_retry_task.done():
+            self._observe_retry_task.cancel()
+            self._observe_retry_task = None
 
     @callback
     def _handle_observation_timeout(self, _now: datetime) -> None:

--- a/custom_components/tewke/coordinator.py
+++ b/custom_components/tewke/coordinator.py
@@ -6,6 +6,8 @@ import asyncio
 from datetime import timedelta
 from typing import TYPE_CHECKING, TypedDict
 
+from homeassistant.core import HassJob, callback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pytewke.error import (
     PyTewkeCoapError,
@@ -39,6 +41,9 @@ _RETRYABLE_ERRORS = (PyTewkeCoapError, PyTewkeUnknownError, TimeoutError)
 
 # Delay sequence (seconds) between successive retry attempts.
 _RETRY_DELAYS: list[float] = [1.0, 2.0, 4.0]
+
+# Seconds of observation silence before we treat the connection as lost.
+_OBSERVATION_TIMEOUT_SECS = 30
 
 # Fallback polling interval.  The coordinator is primarily push-based; this
 # acts as a safety-net so that if observations go silent the coordinator can
@@ -115,31 +120,51 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
         )
         self._observe_setup_lock = asyncio.Lock()
         self._observe_retry_task: asyncio.Task[None] | None = None
+        self._observation_timeout_unsub: Callable[[], None] | None = None
+        self._observation_timeout_job = HassJob(
+            self._handle_observation_timeout, cancel_on_shutdown=True
+        )
 
-    async def _setup_observe(self) -> None:
-        async def retry_setup_observe() -> None:
+    def reset_observation_timeout(self) -> None:
+        """Restart the inactivity timer; call this on every received observation.
+
+        Runs on the event loop (CoAP callbacks are async), so async_call_later
+        is safe to use directly — no call_soon_threadsafe required.
+        """
+        if self._observation_timeout_unsub is not None:
+            self._observation_timeout_unsub()
+        self._observation_timeout_unsub = async_call_later(
+            self.hass, _OBSERVATION_TIMEOUT_SECS, self._observation_timeout_job
+        )
+
+    def cancel_observation_timeout(self) -> None:
+        """Cancel the pending inactivity timer, e.g. on entry unload."""
+        if self._observation_timeout_unsub is not None:
+            self._observation_timeout_unsub()
+            self._observation_timeout_unsub = None
+
+    @callback
+    def _handle_observation_timeout(self, _now: object) -> None:
+        """Fire on the event loop when no observations have arrived for a while."""
+        self.logger.info(
+            "Observations timed out for tap %s, retrying",
+            self.config_entry.runtime_data.tap.wall_dock_id,
+        )
+        self._observation_timeout_unsub = None
+        self.config_entry.runtime_data.observe_active = False
+        if self._observe_retry_task is not None and not self._observe_retry_task.done():
+            return
+
+        async def _retry() -> None:
             try:
                 await self._setup_observe()
             finally:
                 if self._observe_retry_task is asyncio.current_task():
                     self._observe_retry_task = None
 
-        def handle_timeout() -> None:
-            def _schedule() -> None:
-                self.config_entry.runtime_data.observe_active = False
-                if (
-                    self._observe_retry_task is not None
-                    and not self._observe_retry_task.done()
-                ):
-                    return
-                self._observe_retry_task = self.hass.async_create_task(
-                    retry_setup_observe()
-                )
+        self._observe_retry_task = self.hass.async_create_task(_retry())
 
-            # handle_timeout is fired from a threading.Timer thread; schedule
-            # task creation back onto the event loop to keep it thread-safe.
-            self.hass.loop.call_soon_threadsafe(_schedule)
-
+    async def _setup_observe(self) -> None:
         async with self._observe_setup_lock:
             if self.config_entry.runtime_data.observe_active:
                 return
@@ -147,12 +172,7 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
                 "CoAP observations not active for %s; attempting to re-establish",
                 self.config_entry.entry_id,
             )
-            await async_setup_observe(
-                self,
-                self.hass,
-                self.config_entry,
-                timeout_callback=handle_timeout,
-            )
+            await async_setup_observe(self, self.hass, self.config_entry)
 
     async def _async_update_data(self) -> TewkeCoordinatorData:
         """Fetch current state for all resources, retrying on transient errors."""

--- a/custom_components/tewke/coordinator.py
+++ b/custom_components/tewke/coordinator.py
@@ -21,6 +21,7 @@ from .util import async_setup_observe
 if TYPE_CHECKING:
     import logging
     from collections.abc import Awaitable, Callable
+    from datetime import datetime
 
     from homeassistant.core import HomeAssistant
     from pytewke.data import (
@@ -144,7 +145,7 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
             self._observation_timeout_unsub = None
 
     @callback
-    def _handle_observation_timeout(self, _now: object) -> None:
+    def _handle_observation_timeout(self, _now: datetime) -> None:
         """Fire on the event loop when no observations have arrived for a while."""
         self.logger.info(
             "Observations timed out for tap %s, retrying",

--- a/custom_components/tewke/util.py
+++ b/custom_components/tewke/util.py
@@ -78,9 +78,9 @@ async def async_setup_observe(
         This callback is triggered when the scenes on the device change. It
         identifies new scenes and creates a repair issue to configure them.
         """
+        coordinator.reset_observation_timeout()
         if coordinator.data is None:
             return
-        coordinator.reset_observation_timeout()
 
         scene_control_types = entry.runtime_data.scene_control_types
 
@@ -169,9 +169,9 @@ async def async_setup_observe(
         This callback is triggered when the targets on the device change.
         It updates the coordinator with the new target data.
         """
+        coordinator.reset_observation_timeout()
         if coordinator.data is None:
             return
-        coordinator.reset_observation_timeout()
 
         coordinator.async_set_updated_data(
             {
@@ -186,9 +186,9 @@ async def async_setup_observe(
 
         This callback is triggered when the sensors on the device change.
         """
+        coordinator.reset_observation_timeout()
         if coordinator.data is None:
             return
-        coordinator.reset_observation_timeout()
         coordinator.async_set_updated_data({**coordinator.data, "sensors": sensor_data})
 
     def _on_radar_update(radar_data: RadarData) -> None:
@@ -197,9 +197,9 @@ async def async_setup_observe(
 
         This callback is triggered when the radar on the device changes.
         """
+        coordinator.reset_observation_timeout()
         if coordinator.data is None:
             return
-        coordinator.reset_observation_timeout()
         coordinator.async_set_updated_data({**coordinator.data, "radar": radar_data})
 
     def _on_energy_update(energy_data: EnergyData) -> None:
@@ -208,9 +208,9 @@ async def async_setup_observe(
 
         This callback is triggered when the energy on the device changes.
         """
+        coordinator.reset_observation_timeout()
         if coordinator.data is None:
             return
-        coordinator.reset_observation_timeout()
         coordinator.async_set_updated_data({**coordinator.data, "energy": energy_data})
 
     def _on_config_update(config_data: ConfigData) -> None:
@@ -219,9 +219,9 @@ async def async_setup_observe(
 
         This callback is triggered when the config on the device changes.
         """
+        coordinator.reset_observation_timeout()
         if coordinator.data is None:
             return
-        coordinator.reset_observation_timeout()
         coordinator.async_set_updated_data({**coordinator.data, "config": config_data})
 
         new_name = config_data.device_name

--- a/custom_components/tewke/util.py
+++ b/custom_components/tewke/util.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers import device_registry as dr
@@ -62,7 +62,6 @@ async def async_setup_observe(
     coordinator: TewkeCoordinator,
     hass: HomeAssistant,
     entry: TewkeConfigEntry,
-    timeout_callback: Callable[[], None],
 ) -> bool:
     """
     Register CoAP observation callbacks on the Tap and start observing.
@@ -81,6 +80,7 @@ async def async_setup_observe(
         """
         if coordinator.data is None:
             return
+        coordinator.reset_observation_timeout()
 
         scene_control_types = entry.runtime_data.scene_control_types
 
@@ -171,6 +171,7 @@ async def async_setup_observe(
         """
         if coordinator.data is None:
             return
+        coordinator.reset_observation_timeout()
 
         coordinator.async_set_updated_data(
             {
@@ -187,6 +188,7 @@ async def async_setup_observe(
         """
         if coordinator.data is None:
             return
+        coordinator.reset_observation_timeout()
         coordinator.async_set_updated_data({**coordinator.data, "sensors": sensor_data})
 
     def _on_radar_update(radar_data: RadarData) -> None:
@@ -197,6 +199,7 @@ async def async_setup_observe(
         """
         if coordinator.data is None:
             return
+        coordinator.reset_observation_timeout()
         coordinator.async_set_updated_data({**coordinator.data, "radar": radar_data})
 
     def _on_energy_update(energy_data: EnergyData) -> None:
@@ -207,6 +210,7 @@ async def async_setup_observe(
         """
         if coordinator.data is None:
             return
+        coordinator.reset_observation_timeout()
         coordinator.async_set_updated_data({**coordinator.data, "energy": energy_data})
 
     def _on_config_update(config_data: ConfigData) -> None:
@@ -217,6 +221,7 @@ async def async_setup_observe(
         """
         if coordinator.data is None:
             return
+        coordinator.reset_observation_timeout()
         coordinator.async_set_updated_data({**coordinator.data, "config": config_data})
 
         new_name = config_data.device_name
@@ -241,8 +246,6 @@ async def async_setup_observe(
             radar_callback=_on_radar_update,
             energy_callback=_on_energy_update,
             config_change_callback=_on_config_update,
-            timeout_in_secs=30,
-            timeout_callback=timeout_callback,
         )
     except PyTewkeObserveError:
         LOGGER.warning(
@@ -254,6 +257,7 @@ async def async_setup_observe(
         return False
 
     entry.runtime_data.observe_active = True
+    coordinator.reset_observation_timeout()
 
     # Process scenes already fetched during initial discovery
     if coordinator.data and "scenes_all" in coordinator.data:


### PR DESCRIPTION
pytewke's ResettableTimer uses threading.Timer which fires the timeout callback on a background OS thread. This requires call_soon_threadsafe to safely schedule work onto the event loop, and silently drops the call if the loop is closed during HA shutdown.

Replace with a fully asyncio-native approach:
- TewkeCoordinator.reset_observation_timeout() schedules a fresh HA async_call_later timer; called from every observation callback (which already run on the event loop via aiocoap)
- _handle_observation_timeout() is a @callback that fires on the event loop — async_create_task is safe to call directly, no call_soon_threadsafe needed
- cancel_observation_timeout() registered as an async_on_unload handler so the timer is cleanly cancelled on entry unload
- timeout_in_secs / timeout_callback removed from tap.observe() call so pytewke's ResettableTimer is never created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added inactivity detection for observations that automatically triggers re-establishment when data stops arriving.
  * Improved error handling to better distinguish between transient and non-transient failures during connection retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->