### PR TITLE
Add debug logging for connection loss diagnostics

### DIFF
--- a/custom_components/tewke/__init__.py
+++ b/custom_components/tewke/__init__.py
@@ -32,12 +32,17 @@ async def async_setup_entry(
     entry: TewkeConfigEntry,
 ) -> bool:
     """Set up a Tewke device from a config entry."""
-    tap = pytewke.Tap(entry.data[CONF_HOST])
+    host = entry.data[CONF_HOST]
+    LOGGER.debug("[%s] async_setup_entry: starting setup for host %s", entry.entry_id, host)
+
+    tap = pytewke.Tap(host)
 
     try:
         await tap.discover()
+        LOGGER.debug("[%s] Tap discovery succeeded", entry.entry_id)
     except PyTewkeDiscoveryError as err:
-        msg = f"Unable to connect to Tewke device at {entry.data[CONF_HOST]}"
+        msg = f"Unable to connect to Tewke device at {host}"
+        LOGGER.debug("[%s] Tap discovery failed: %s", entry.entry_id, err)
         raise ConfigEntryNotReady(msg) from err
 
     tewke_coordinator = TewkeCoordinator(
@@ -49,19 +54,22 @@ async def async_setup_entry(
     tewke_coordinator.config_entry = entry
 
     entry.runtime_data = TewkeData(
-        host=entry.data[CONF_HOST],
+        host=host,
         tap=tap,
         coordinator=tewke_coordinator,
         scene_control_types=entry.data.get("scene_control_types", {}),
     )
 
+    LOGGER.debug("[%s] Running first coordinator refresh", entry.entry_id)
     await tewke_coordinator.async_config_entry_first_refresh()
+    LOGGER.debug("[%s] First coordinator refresh complete", entry.entry_id)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     entry.async_on_unload(tewke_coordinator.cancel_observation_timeout)
     entry.async_on_unload(tap.close)
 
+    LOGGER.debug("[%s] async_setup_entry: setup complete", entry.entry_id)
     return True
 
 
@@ -70,7 +78,10 @@ async def async_unload_entry(
     entry: TewkeConfigEntry,
 ) -> bool:
     """Handle removal of an entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    LOGGER.debug("[%s] async_unload_entry: unloading platforms", entry.entry_id)
+    result = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    LOGGER.debug("[%s] async_unload_entry: unload result=%s", entry.entry_id, result)
+    return result
 
 
 async def async_reload_entry(
@@ -78,4 +89,5 @@ async def async_reload_entry(
     entry: TewkeConfigEntry,
 ) -> None:
     """Reload config entry."""
+    LOGGER.debug("[%s] async_reload_entry: reload triggered", entry.entry_id)
     await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/tewke/coordinator.py
+++ b/custom_components/tewke/coordinator.py
@@ -132,6 +132,11 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
         Runs on the event loop (CoAP callbacks are async), so async_call_later
         is safe to use directly — no call_soon_threadsafe required.
         """
+        LOGGER.debug(
+            "[%s] Observation received; resetting %ds inactivity timer",
+            self.config_entry.entry_id,
+            _OBSERVATION_TIMEOUT_SECS,
+        )
         if self._observation_timeout_unsub is not None:
             self._observation_timeout_unsub()
         self._observation_timeout_unsub = async_call_later(
@@ -144,6 +149,10 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
         Called on entry unload to prevent the retry task from running against
         stale runtime_data after the entry has been torn down.
         """
+        LOGGER.debug(
+            "[%s] Cancelling observation timeout and any pending retry task",
+            self.config_entry.entry_id,
+        )
         if self._observation_timeout_unsub is not None:
             self._observation_timeout_unsub()
             self._observation_timeout_unsub = None
@@ -154,14 +163,26 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
     @callback
     def _handle_observation_timeout(self, _now: datetime) -> None:
         """Fire on the event loop when no observations have arrived for a while."""
-        self.logger.info(
-            "Observations timed out for tap %s, retrying",
-            self.config_entry.runtime_data.tap.wall_dock_id,
+        entry_id = self.config_entry.entry_id
+        tap_id = self.config_entry.runtime_data.tap.wall_dock_id
+        LOGGER.warning(
+            "[%s] Observation inactivity timeout fired for tap %s "
+            "(no observation received for %ds)",
+            entry_id,
+            tap_id,
+            _OBSERVATION_TIMEOUT_SECS,
         )
         self._observation_timeout_unsub = None
         self.config_entry.runtime_data.observe_active = False
+
         if self._observe_retry_task is not None and not self._observe_retry_task.done():
+            LOGGER.debug(
+                "[%s] Retry task already in flight; skipping new task creation",
+                entry_id,
+            )
             return
+
+        LOGGER.debug("[%s] Spawning observe retry task", entry_id)
 
         async def _retry() -> None:
             try:
@@ -173,30 +194,51 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
         self._observe_retry_task = self.hass.async_create_task(_retry())
 
     async def _setup_observe(self) -> None:
+        entry_id = self.config_entry.entry_id
+        LOGGER.debug("[%s] _setup_observe: acquiring lock", entry_id)
         async with self._observe_setup_lock:
             if self.config_entry.runtime_data.observe_active:
+                LOGGER.debug(
+                    "[%s] _setup_observe: observe already active, skipping", entry_id
+                )
                 return
             LOGGER.info(
-                "CoAP observations not active for %s; attempting to re-establish",
-                self.config_entry.entry_id,
+                "[%s] CoAP observations not active; attempting to re-establish",
+                entry_id,
             )
-            await async_setup_observe(self, self.hass, self.config_entry)
+            success = await async_setup_observe(self, self.hass, self.config_entry)
+            LOGGER.debug(
+                "[%s] _setup_observe: async_setup_observe returned %s",
+                entry_id,
+                success,
+            )
 
     async def _async_update_data(self) -> TewkeCoordinatorData:
         """Fetch current state for all resources, retrying on transient errors."""
+        entry_id = self.config_entry.entry_id
+        observe_active = self.config_entry.runtime_data.observe_active
+        LOGGER.debug(
+            "[%s] _async_update_data: starting poll (observe_active=%s)",
+            entry_id,
+            observe_active,
+        )
         await self._setup_observe()
 
         tap = self.config_entry.runtime_data.tap
 
+        LOGGER.debug("[%s] Fetching scenes and targets from tap", entry_id)
         try:
             scenes_all = await _fetch_with_retries(tap.get_scenes)
+            LOGGER.debug("[%s] Fetched %d scene(s)", entry_id, len(scenes_all))
             targets = await _fetch_with_retries(tap.get_targets)
+            LOGGER.debug("[%s] Fetched %d target(s)", entry_id, len(targets))
         except (
             PyTewkeCoapError,
             PyTewkeInvalidResponseError,
             PyTewkeUnknownError,
             TimeoutError,
         ) as err:
+            LOGGER.debug("[%s] Fatal error fetching scenes/targets: %s", entry_id, err)
             msg = f"Error communicating with Tewke Tap: {err}"
             raise UpdateFailed(msg) from err
 
@@ -207,50 +249,64 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
             if scene_id in scene_control_types
         }
 
+        LOGGER.debug("[%s] Fetching supplementary resources (sensors/radar/energy/config)", entry_id)
+
         try:
             sensors: SensorData | None = await tap.get_sensors()
+            LOGGER.debug("[%s] Fetched sensor data: %s", entry_id, sensors)
         except (
             PyTewkeCoapError,
             PyTewkeInvalidResponseError,
             PyTewkeUnknownError,
             TimeoutError,
         ) as err:
-            LOGGER.debug("Sensor data not available from Tewke Tap: %s", err)
+            LOGGER.debug("[%s] Sensor data not available from Tewke Tap: %s", entry_id, err)
             sensors = None
 
         try:
             radar: RadarData | None = await tap.get_radar()
+            LOGGER.debug("[%s] Fetched radar data: %s", entry_id, radar)
         except (
             PyTewkeCoapError,
             PyTewkeInvalidResponseError,
             PyTewkeUnknownError,
             TimeoutError,
         ) as err:
-            LOGGER.debug("Radar data not available from Tewke Tap: %s", err)
+            LOGGER.debug("[%s] Radar data not available from Tewke Tap: %s", entry_id, err)
             radar = None
 
         try:
             energy: EnergyData | None = await tap.get_energy()
+            LOGGER.debug("[%s] Fetched energy data: %s", entry_id, energy)
         except (
             PyTewkeCoapError,
             PyTewkeInvalidResponseError,
             PyTewkeUnknownError,
             TimeoutError,
         ) as err:
-            LOGGER.debug("Energy data not available from Tewke Tap: %s", err)
+            LOGGER.debug("[%s] Energy data not available from Tewke Tap: %s", entry_id, err)
             energy = None
 
         try:
             config: ConfigData | None = await tap.get_config()
+            LOGGER.debug("[%s] Fetched config data: %s", entry_id, config)
         except (
             PyTewkeCoapError,
             PyTewkeInvalidResponseError,
             PyTewkeUnknownError,
             TimeoutError,
         ) as err:
-            LOGGER.debug("Config data not available from Tewke Tap: %s", err)
+            LOGGER.debug("[%s] Config data not available from Tewke Tap: %s", entry_id, err)
             config = None
 
+        LOGGER.debug(
+            "[%s] _async_update_data: poll complete "
+            "(scenes=%d configured/%d total, targets=%d)",
+            entry_id,
+            len(configured_scenes),
+            len(scenes_all),
+            len(targets),
+        )
         return TewkeCoordinatorData(
             scenes=configured_scenes,
             scenes_all=scenes_all,

--- a/custom_components/tewke/util.py
+++ b/custom_components/tewke/util.py
@@ -70,6 +70,9 @@ async def async_setup_observe(
     The ``observe_active`` flag on ``entry.runtime_data`` is set accordingly.
     """
     tap = entry.runtime_data.tap
+    host = entry.data.get(CONF_NAME, entry.entry_id)
+
+    LOGGER.debug("[%s] Setting up CoAP observations", host)
 
     def _on_scene_update(scenes: dict[str, Scene]) -> None:
         """
@@ -78,8 +81,10 @@ async def async_setup_observe(
         This callback is triggered when the scenes on the device change. It
         identifies new scenes and creates a repair issue to configure them.
         """
+        LOGGER.debug("[%s] Scene update received: %d scene(s)", host, len(scenes))
         coordinator.reset_observation_timeout()
         if coordinator.data is None:
+            LOGGER.debug("[%s] Scene update ignored: coordinator has no data yet", host)
             return
 
         scene_control_types = entry.runtime_data.scene_control_types
@@ -122,6 +127,12 @@ async def async_setup_observe(
             if scene_id in scene_control_types
         }
 
+        LOGGER.debug(
+            "[%s] Updating coordinator: %d configured scene(s) of %d total",
+            host,
+            len(configured_scenes),
+            len(scenes),
+        )
         coordinator.async_set_updated_data(
             {
                 **coordinator.data,
@@ -135,6 +146,7 @@ async def async_setup_observe(
             sid for sid in entry.runtime_data.pending_scenes if sid not in scenes
         ]
         for sid in stale_ids:
+            LOGGER.debug("[%s] Removing stale pending scene: %s", host, sid)
             del entry.runtime_data.pending_scenes[sid]
 
         new_scenes = {
@@ -169,8 +181,12 @@ async def async_setup_observe(
         This callback is triggered when the targets on the device change.
         It updates the coordinator with the new target data.
         """
+        LOGGER.debug("[%s] Target update received: %d target(s)", host, len(targets))
         coordinator.reset_observation_timeout()
         if coordinator.data is None:
+            LOGGER.debug(
+                "[%s] Target update ignored: coordinator has no data yet", host
+            )
             return
 
         coordinator.async_set_updated_data(
@@ -186,8 +202,12 @@ async def async_setup_observe(
 
         This callback is triggered when the sensors on the device change.
         """
+        LOGGER.debug("[%s] Sensor update received: %s", host, sensor_data)
         coordinator.reset_observation_timeout()
         if coordinator.data is None:
+            LOGGER.debug(
+                "[%s] Sensor update ignored: coordinator has no data yet", host
+            )
             return
         coordinator.async_set_updated_data({**coordinator.data, "sensors": sensor_data})
 
@@ -197,8 +217,12 @@ async def async_setup_observe(
 
         This callback is triggered when the radar on the device changes.
         """
+        LOGGER.debug("[%s] Radar update received: %s", host, radar_data)
         coordinator.reset_observation_timeout()
         if coordinator.data is None:
+            LOGGER.debug(
+                "[%s] Radar update ignored: coordinator has no data yet", host
+            )
             return
         coordinator.async_set_updated_data({**coordinator.data, "radar": radar_data})
 
@@ -208,8 +232,12 @@ async def async_setup_observe(
 
         This callback is triggered when the energy on the device changes.
         """
+        LOGGER.debug("[%s] Energy update received: %s", host, energy_data)
         coordinator.reset_observation_timeout()
         if coordinator.data is None:
+            LOGGER.debug(
+                "[%s] Energy update ignored: coordinator has no data yet", host
+            )
             return
         coordinator.async_set_updated_data({**coordinator.data, "energy": energy_data})
 
@@ -219,8 +247,12 @@ async def async_setup_observe(
 
         This callback is triggered when the config on the device changes.
         """
+        LOGGER.debug("[%s] Config update received: %s", host, config_data)
         coordinator.reset_observation_timeout()
         if coordinator.data is None:
+            LOGGER.debug(
+                "[%s] Config update ignored: coordinator has no data yet", host
+            )
             return
         coordinator.async_set_updated_data({**coordinator.data, "config": config_data})
 
@@ -239,6 +271,7 @@ async def async_setup_observe(
                 device_registry.async_update_device(device.id, name=new_name)
 
     try:
+        LOGGER.debug("[%s] Calling tap.observe()", host)
         await tap.observe(
             scene_callback=_on_scene_update,
             target_callback=_on_target_update,
@@ -250,17 +283,19 @@ async def async_setup_observe(
     except PyTewkeObserveError:
         LOGGER.warning(
             "Failed to set up CoAP observations for %s; will retry on next poll",
-            entry.data.get(CONF_NAME, entry.entry_id),
+            host,
             exc_info=True,
         )
         entry.runtime_data.observe_active = False
         return False
 
+    LOGGER.debug("[%s] CoAP observations active; starting inactivity timer", host)
     entry.runtime_data.observe_active = True
     coordinator.reset_observation_timeout()
 
     # Process scenes already fetched during initial discovery
     if coordinator.data and "scenes_all" in coordinator.data:
+        LOGGER.debug("[%s] Processing initial scenes from first refresh", host)
         _on_scene_update(coordinator.data["scenes_all"])
 
     return True


### PR DESCRIPTION
Log on every observation callback (resource type + data summary), inactivity timer resets/cancellations, timeout fires, setup_observe entry/exit and lock state, each poll fetch step with counts, and setup/unload lifecycle in __init__.