### PR TITLE
refactor: Skip redundant full data fetches with active observations

### DIFF
--- a/custom_components/tewke/coordinator.py
+++ b/custom_components/tewke/coordinator.py
@@ -96,10 +96,11 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
     Coordinator for all Tewke state (scenes, targets, sensors).
 
     Updates are primarily push-based via CoAP observation callbacks registered
-    in `async_setup_entry`.  `_async_update_data` runs at initial setup and
-    whenever an entity service call triggers `async_request_refresh`.  A
-    periodic fallback interval (`_RECOVERY_INTERVAL`) ensures the coordinator
-    can self-heal if observations go silent.
+    in `async_setup_entry`.  `_async_update_data` runs at initial setup and on
+    the periodic fallback interval (`_RECOVERY_INTERVAL`), but skips the manual
+    fetch if observations are already active and data is populated — observations
+    keep the data current.  The full fetch only runs when data is absent (first
+    boot) or observations have gone silent.
 
     See TewkeCoordinatorData for the full shape of the coordinator data.
     """
@@ -183,8 +184,17 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
             await async_setup_observe(self, self.hass, self.config_entry)
 
     async def _async_update_data(self) -> TewkeCoordinatorData:
-        """Fetch current state for all resources, retrying on transient errors."""
+        """Fetch current state for all resources, retrying on transient errors.
+
+        If CoAP observations are active and we already have data, skip the
+        manual fetch entirely — observations will keep the data current.
+        The full fetch only runs when we have no data yet (initial startup)
+        or when observations are down and we need to fall back to polling.
+        """
         await self._setup_observe()
+
+        if self.config_entry.runtime_data.observe_active and self.data is not None:
+            return self.data
 
         tap = self.config_entry.runtime_data.tap
 

--- a/custom_components/tewke/target.py
+++ b/custom_components/tewke/target.py
@@ -99,6 +99,9 @@ class TewkeTargetLight(TewkeEntity, LightEntity):
             await self.coordinator.config_entry.runtime_data.tap.set_target(
                 target=self._target_index, brightness=tewke_brightness
             )
+            target.is_on = True
+            target.brightness = tewke_brightness
+            self.async_write_ha_state()
             await self.coordinator.async_request_refresh()
         except PyTewkeInvalidWallDockError:
             LOGGER.error(
@@ -123,6 +126,11 @@ class TewkeTargetLight(TewkeEntity, LightEntity):
             await self.coordinator.config_entry.runtime_data.tap.set_target(
                 target=self._target_index, brightness=0
             )
+            target = self._target
+            if target is not None:
+                target.is_on = False
+                target.brightness = 0
+                self.async_write_ha_state()
             await self.coordinator.async_request_refresh()
         except PyTewkeInvalidWallDockError:
             LOGGER.error(

--- a/custom_components/tewke/target.py
+++ b/custom_components/tewke/target.py
@@ -99,8 +99,10 @@ class TewkeTargetLight(TewkeEntity, LightEntity):
             await self.coordinator.config_entry.runtime_data.tap.set_target(
                 target=self._target_index, brightness=tewke_brightness
             )
-            target.is_on = tewke_brightness != 0
-            target.brightness = tewke_brightness
+            target = self._target
+            if target is not None:
+                target.is_on = tewke_brightness != 0
+                target.brightness = tewke_brightness
             self.async_write_ha_state()
             await self.coordinator.async_request_refresh()
         except PyTewkeInvalidWallDockError:

--- a/custom_components/tewke/target.py
+++ b/custom_components/tewke/target.py
@@ -99,7 +99,7 @@ class TewkeTargetLight(TewkeEntity, LightEntity):
             await self.coordinator.config_entry.runtime_data.tap.set_target(
                 target=self._target_index, brightness=tewke_brightness
             )
-            target.is_on = True
+            target.is_on = tewke_brightness != 0
             target.brightness = tewke_brightness
             self.async_write_ha_state()
             await self.coordinator.async_request_refresh()

--- a/custom_components/tewke/target.py
+++ b/custom_components/tewke/target.py
@@ -103,7 +103,7 @@ class TewkeTargetLight(TewkeEntity, LightEntity):
             if target is not None:
                 target.is_on = tewke_brightness != 0
                 target.brightness = tewke_brightness
-            self.async_write_ha_state()
+                self.async_write_ha_state()
             await self.coordinator.async_request_refresh()
         except PyTewkeInvalidWallDockError:
             LOGGER.error(


### PR DESCRIPTION
The `_async_update_data` method now avoids performing a full data fetch if CoAP observations are already active and data is present. This ensures the coordinator relies on the push-based observation mechanism as the primary source of updates, only falling back to a full fetch for initial setup or recovery from observation failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Light on/off now updates device state immediately for snappier UI feedback.

* **Refactor**
  * Coordinator polling reduced: when push observations are active, redundant full data fetches are skipped to avoid unnecessary updates and latency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tewke/hacs-integration/pull/40)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->