### PR TITLE
Rename project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Tewke Home Assistant Integration
 
 ![status_badge](https://img.shields.io/badge/status-beta-red)
-[![Validate HACS](https://github.com/tewke/hacs-integration/actions/workflows/hacs.yml/badge.svg)](https://github.com/tewke/hacs-integration/actions/workflows/hacs.yml)
-[![Validate hassfest](https://github.com/tewke/hacs-integration/actions/workflows/hassfest.yml/badge.svg)](https://github.com/tewke/hacs-integration/actions/workflows/hassfest.yml)
+[![Validate HACS](https://github.com/tewke/ha-custom-integration/actions/workflows/hacs.yml/badge.svg)](https://github.com/tewke/ha-custom-integration/actions/workflows/hacs.yml)
+[![Validate hassfest](https://github.com/tewke/ha-custom-integration/actions/workflows/hassfest.yml/badge.svg)](https://github.com/tewke/ha-custom-integration/actions/workflows/hassfest.yml)
 
 - [Tewke Home Assistant Integration](#tewke-home-assistant-integration)
     - [Features](#features)
@@ -14,7 +14,7 @@
 
 A Home Assistant integration for Tewke devices.
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=tewke&repository=hacs-integration&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=tewke&repository=ha-custom-integration&category=integration)
 
 ## Features
 
@@ -55,7 +55,7 @@ Click the button at the top of this readme to add this repository to HACS and in
 
 ### Manual
 
-You should use the [latest release on Github](https://github.com/tewke/hacs-integration/releases/latest).
+You should use the [latest release on Github](https://github.com/tewke/ha-custom-integration/releases/latest).
 
 To install, place the contents of `custom_components` into the
 `<config directory>/custom_components` folder of your Home Assistant
@@ -64,4 +64,4 @@ instance for the integration to be picked up.
 
 ## Issues
 
-If you have found a bug or have a feature request, please [raise it](https://github.com/tewke/hacs-integration/issues).
+If you have found a bug or have a feature request, please [raise it](https://github.com/tewke/ha-custom-integration/issues).

--- a/custom_components/tewke/manifest.json
+++ b/custom_components/tewke/manifest.json
@@ -5,10 +5,10 @@
     "@1NFR4R3D"
   ],
   "config_flow": true,
-  "documentation": "https://github.com/tewke/hacs-integration",
+  "documentation": "https://github.com/tewke/ha-custom-integration",
   "integration_type": "device",
   "iot_class": "local_push",
-  "issue_tracker": "https://github.com/tewke/hacs-integration/issues",
+  "issue_tracker": "https://github.com/tewke/ha-custom-integration/issues",
   "loggers": [
     "pytewke"
   ],

--- a/custom_components/tewke/manifest.json
+++ b/custom_components/tewke/manifest.json
@@ -16,7 +16,7 @@
   "requirements": [
     "pytewke==0.5.1"
   ],
-  "version": "0.1.0",
+  "version": "0.1.1",
   "zeroconf": [
     {
       "type": "_tewke-coap._udp.local."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-custom-integration"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.14.2"
 dependencies = [
     "colorlog==6.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "hacs-integration"
+name = "ha-custom-integration"
 version = "0.1.0"
 requires-python = ">=3.14.2"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ wheels = [
 ]
 
 [[package]]
-name = "hacs-integration"
+name = "ha-custom-integration"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -902,6 +902,37 @@ wheels = [
 ]
 
 [[package]]
+name = "ha-custom-integration"
+version = "0.1.1"
+source = { virtual = "." }
+dependencies = [
+    { name = "colorlog" },
+    { name = "homeassistant" },
+    { name = "pytewke" },
+    { name = "voluptuous" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "black" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "colorlog", specifier = "==6.10.1" },
+    { name = "homeassistant", specifier = "==2026.5.1" },
+    { name = "pytewke", specifier = "==0.5.1" },
+    { name = "voluptuous", specifier = ">=0.15.2" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "black", specifier = ">=26.3.1" },
+    { name = "ruff", specifier = ">=0.15.8" },
+]
+
+[[package]]
 name = "habluetooth"
 version = "5.11.2"
 source = { registry = "https://pypi.org/simple" }
@@ -935,37 +966,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/1e/f62f94c38a5e28e81728423e6402fcc33fbf58cb1e59cf512f2569dd0fe9/habluetooth-5.11.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5f15a095d032b91258c71bb387155dcda30d74ef9c7715733f6ba77dab2b8f0b", size = 1377465, upload-time = "2026-03-28T00:13:31.499Z" },
     { url = "https://files.pythonhosted.org/packages/f3/62/2d3a07d790ecc01198d19c9fb569595125cd1a84df50391516163c66af3d/habluetooth-5.11.2-cp314-cp314t-win32.whl", hash = "sha256:f118700eaeaafbf998cedf82b75641f61fd2c0c8855ce8196cfdac4510cf9aeb", size = 973241, upload-time = "2026-03-28T00:13:33.129Z" },
     { url = "https://files.pythonhosted.org/packages/5c/f9/a2deb9acfe08bfdf211ab609687a66222c39ca97328fd7d733f9542297ae/habluetooth-5.11.2-cp314-cp314t-win_amd64.whl", hash = "sha256:ce6e4a0cb6ab6081901696e8990f4236608ad41c5bf845f1b714e925058a7559", size = 1147077, upload-time = "2026-03-28T00:13:35.173Z" },
-]
-
-[[package]]
-name = "ha-custom-integration"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "colorlog" },
-    { name = "homeassistant" },
-    { name = "pytewke" },
-    { name = "voluptuous" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "black" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "colorlog", specifier = "==6.10.1" },
-    { name = "homeassistant", specifier = "==2026.5.1" },
-    { name = "pytewke", specifier = "==0.5.1" },
-    { name = "voluptuous", specifier = ">=0.15.2" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "black", specifier = ">=26.3.1" },
-    { name = "ruff", specifier = ">=0.15.8" },
 ]
 
 [[package]]


### PR DESCRIPTION
HACS requires the name to not contain `hacs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.1.
  * Updated documentation URLs and issue tracker references in integration configuration.

* **Documentation**
  * Updated README with new documentation and repository links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tewke/ha-custom-integration/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->