### PR TITLE
feat: Add restart button and energy override number

### DIFF
--- a/custom_components/tewke/__init__.py
+++ b/custom_components/tewke/__init__.py
@@ -20,8 +20,10 @@ if TYPE_CHECKING:
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.FAN,
     Platform.LIGHT,
+    Platform.NUMBER,
     Platform.SENSOR,
     Platform.SWITCH,
 ]

--- a/custom_components/tewke/button.py
+++ b/custom_components/tewke/button.py
@@ -1,0 +1,51 @@
+"""
+Button platform for the Tewke integration.
+
+Exposes a restart (reboot) button for the Tewke Tap Panel.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
+from homeassistant.helpers.entity import EntityCategory
+
+from .entity import TewkeEntity
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import TewkeCoordinator
+    from .data import TewkeConfigEntry
+
+
+async def async_setup_entry(
+    _hass: HomeAssistant,
+    entry: TewkeConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Tewke button entities from a config entry."""
+    coordinator = entry.runtime_data.coordinator
+    async_add_entities([TewkeRestartButton(coordinator=coordinator)])
+
+
+class TewkeRestartButton(TewkeEntity, ButtonEntity):
+    """Button entity to restart the Tewke Tap Panel."""
+
+    _attr_name = "Restart"
+    _attr_device_class = ButtonDeviceClass.RESTART
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: TewkeCoordinator) -> None:
+        """Initialise the restart button entity."""
+        super().__init__(coordinator)
+        hardware_id = coordinator.data["config"].hardware_id
+        self._attr_unique_id = f"{hardware_id}_restart"
+
+    async def async_press(self) -> None:
+        """Send a restart command to the Tap Panel."""
+        tap = self.coordinator.config_entry.runtime_data.tap
+        await tap.restart()

--- a/custom_components/tewke/coordinator.py
+++ b/custom_components/tewke/coordinator.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from pytewke.data import (
         ConfigData,
         EnergyData,
+        EnergyOverrideData,
         RadarData,
         Scene,
         SensorData,
@@ -88,6 +89,7 @@ class TewkeCoordinatorData(TypedDict):
     sensors: SensorData | None
     radar: RadarData | None
     energy: EnergyData | None
+    energy_override: EnergyOverrideData | None
     config: ConfigData | None
 
 
@@ -259,6 +261,17 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
             energy = None
 
         try:
+            energy_override: EnergyOverrideData | None = await tap.get_energy_override()
+        except (
+            PyTewkeCoapError,
+            PyTewkeInvalidResponseError,
+            PyTewkeUnknownError,
+            TimeoutError,
+        ) as err:
+            LOGGER.debug("Energy override data not available from Tewke Tap: %s", err)
+            energy_override = None
+
+        try:
             config: ConfigData | None = await tap.get_config()
         except (
             PyTewkeCoapError,
@@ -276,5 +289,6 @@ class TewkeCoordinator(DataUpdateCoordinator[TewkeCoordinatorData]):
             sensors=sensors,
             radar=radar,
             energy=energy,
+            energy_override=energy_override,
             config=config,
         )

--- a/custom_components/tewke/manifest.json
+++ b/custom_components/tewke/manifest.json
@@ -14,9 +14,9 @@
   ],
   "quality_scale": "bronze",
   "requirements": [
-    "pytewke==0.5.1"
+    "pytewke==0.5.3"
   ],
-  "version": "0.1.1",
+  "version": "0.1.2",
   "zeroconf": [
     {
       "type": "_tewke-coap._udp.local."

--- a/custom_components/tewke/number.py
+++ b/custom_components/tewke/number.py
@@ -1,0 +1,78 @@
+"""
+Number platform for the Tewke integration.
+
+Exposes the energy override as a settable number entity (watts).
+Setting a value activates the override; setting it to 0 clears it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
+from homeassistant.const import UnitOfPower
+
+from .entity import TewkeEntity
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import TewkeCoordinator
+    from .data import TewkeConfigEntry
+
+
+async def async_setup_entry(
+    _hass: HomeAssistant,
+    entry: TewkeConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Tewke number entities from a config entry."""
+    coordinator = entry.runtime_data.coordinator
+
+    if coordinator.data.get("energy_override") is not None:
+        async_add_entities([TewkeEnergyOverrideNumber(coordinator=coordinator)])
+
+
+class TewkeEnergyOverrideNumber(TewkeEntity, NumberEntity):
+    """
+    Number entity to get/set the Tewke energy override.
+
+    A positive value (watts) activates the override; setting 0 clears it.
+    """
+
+    _attr_name = "Energy Override"
+    _attr_device_class = NumberDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_mode = NumberMode.BOX
+    _attr_entity_registry_enabled_default = False
+    _attr_native_min_value = 0
+    _attr_native_max_value = 1_000_000
+    _attr_native_step = 0.1
+
+    def __init__(self, coordinator: TewkeCoordinator) -> None:
+        """Initialise the energy override number entity."""
+        super().__init__(coordinator)
+        hardware_id = coordinator.data["config"].hardware_id
+        self._attr_unique_id = f"{hardware_id}_energy_override"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current override value in watts, or None when inactive."""
+        energy_override = self.coordinator.data.get("energy_override")
+        if energy_override is None or not energy_override.active:
+            return None
+        return energy_override.override
+
+    async def async_set_native_value(self, value: float) -> None:
+        """
+        Set or clear the energy override.
+
+        Pass 0 to clear the override; any positive value activates it.
+        """
+        tap = self.coordinator.config_entry.runtime_data.tap
+        override_value: float | None = value if value > 0 else None
+        updated = await tap.set_energy_override(override_value)
+
+        current = self.coordinator.data
+        self.coordinator.async_set_updated_data({**current, "energy_override": updated})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "ha-custom-integration"
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.14.2"
 dependencies = [
     "colorlog==6.10.1",
     "homeassistant==2026.5.1",
-    "pytewke==0.5.1",
+    "pytewke==0.5.3",
     "voluptuous>=0.15.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -903,7 +903,7 @@ wheels = [
 
 [[package]]
 name = "ha-custom-integration"
-version = "0.1.1"
+version = "0.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "colorlog" },
@@ -922,7 +922,7 @@ dev = [
 requires-dist = [
     { name = "colorlog", specifier = "==6.10.1" },
     { name = "homeassistant", specifier = "==2026.5.1" },
-    { name = "pytewke", specifier = "==0.5.1" },
+    { name = "pytewke", specifier = "==0.5.3" },
     { name = "voluptuous", specifier = ">=0.15.2" },
 ]
 
@@ -1684,16 +1684,16 @@ sdist = { url = "https://files.pythonhosted.org/packages/08/64/a99f27d3b4347486c
 
 [[package]]
 name = "pytewke"
-version = "0.5.1"
+version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiocoap" },
     { name = "cbor2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/e0/cb053aa0e808d0de4a5d2667062a75f783a5f9f59e2ff53ae2d7111e7126/pytewke-0.5.1.tar.gz", hash = "sha256:b2283bf7dd4f0e70fe5ac6f0df79e107f23e8e6a93c8f21a75e44236f2b49a8b", size = 36154894, upload-time = "2026-05-13T14:53:39.701Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/9f/9414f77d177e8ba4b262c7dcc17edab7e3f4c14986270c8c7108b7cd4112/pytewke-0.5.3.tar.gz", hash = "sha256:af050d504a19a79d26b5c68f2be4778703669853a9ab700d2c2172d0ae17c267", size = 36718795, upload-time = "2026-05-18T15:38:45.243Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/37/9cd9c0b369c16a0ff666efe1a846825447ee70686d1571906a84b2211f5f/pytewke-0.5.1-py3-none-any.whl", hash = "sha256:59b5e263becb3814e8409af2bb31fba82623a7243e051aa7fe5bafb9fce73a98", size = 24547, upload-time = "2026-05-13T14:53:37.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/51/196a52262e8297fc3557ffa53a4b10c547f5a5e5e6e5480f38bc76778b06/pytewke-0.5.3-py3-none-any.whl", hash = "sha256:0aec49b1cb236202ed7aa21a9757c23aecd8d84227276bf7ae8b25d1748fafc6", size = 25004, upload-time = "2026-05-18T15:38:43.59Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Introduces a new `button` entity to trigger a restart of the Tewke Tap Panel. Adds a `number` entity to view and set the energy override, allowing control over the panel's power consumption. Both entities are disabled by default.

Bumps `pytewke` dependency to `0.5.3` to support these new functionalities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a restart button for the Tewke Tap Panel to enable manual device restarts
  * Added energy override control as a writable number entity allowing users to adjust power overrides in watts (0–1,000,000), with zero clearing any active override

* **Chores**
  * Updated pytewke library dependency from 0.5.1 to 0.5.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tewke/ha-custom-integration/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->