### PR TITLE
fix: Remove auto reload and retrieve fan scene default dimming dynamically

### DIFF
--- a/custom_components/tewke/__init__.py
+++ b/custom_components/tewke/__init__.py
@@ -60,7 +60,6 @@ async def async_setup_entry(
     await tewke_coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     entry.async_on_unload(tewke_coordinator.cancel_observation_timeout)
     entry.async_on_unload(tap.close)
 
@@ -73,11 +72,3 @@ async def async_unload_entry(
 ) -> bool:
     """Handle removal of an entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-
-async def async_reload_entry(
-    hass: HomeAssistant,
-    entry: TewkeConfigEntry,
-) -> None:
-    """Reload config entry."""
-    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/tewke/fan.py
+++ b/custom_components/tewke/fan.py
@@ -9,11 +9,9 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import (
     CONF_DISABLED_SCENES,
-    DEFAULT_SCENE_FAN_DIMMING,
     DISPATCHER_ADD_SCENES,
 )
 from .scene import TewkeSceneFan
-from .util import _get_default_scene_fan_dimming
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -33,13 +31,10 @@ async def async_setup_entry(
     scene_control_types = entry.runtime_data.scene_control_types
     disabled_scenes: list[str] = entry.data.get(CONF_DISABLED_SCENES, [])
 
-    fan_default_speeds = _get_default_scene_fan_dimming(entry)
-
     async_add_entities(
         TewkeSceneFan(
             coordinator=coordinator,
             scene=scene,
-            default_dimming=fan_default_speeds.get(scene_id, DEFAULT_SCENE_FAN_DIMMING),
             enabled_default=scene_id not in disabled_scenes,
         )
         for scene_id, scene in coordinator.data["scenes"].items()
@@ -48,14 +43,10 @@ async def async_setup_entry(
 
     @callback
     def _async_add_new_scenes(scenes: list[Scene]) -> None:
-        current_dimming = _get_default_scene_fan_dimming(entry)
         async_add_entities(
             TewkeSceneFan(
                 coordinator=coordinator,
                 scene=scene,
-                default_dimming=current_dimming.get(
-                    scene.id, DEFAULT_SCENE_FAN_DIMMING
-                ),
                 enabled_default=scene.id
                 not in entry.data.get(CONF_DISABLED_SCENES, []),
             )

--- a/custom_components/tewke/scene.py
+++ b/custom_components/tewke/scene.py
@@ -28,9 +28,13 @@ from pytewke.error import (
     PyTewkeUnknownError,
 )
 
-from .const import LOGGER
+from .const import DEFAULT_SCENE_FAN_DIMMING, LOGGER
 from .entity import TewkeEntity
-from .util import _ha_to_tewke_brightness, _tewke_to_ha_brightness
+from .util import (
+    _get_default_scene_fan_dimming,
+    _ha_to_tewke_brightness,
+    _tewke_to_ha_brightness,
+)
 
 if TYPE_CHECKING:
     from pytewke.data import Scene
@@ -207,12 +211,17 @@ class TewkeSceneFan(TewkeSceneEntity, FanEntity):
         coordinator: TewkeCoordinator,
         scene: Scene,
         *,
-        default_dimming: int = 50,
         enabled_default: bool = True,
     ) -> None:
         """Initialise the scene fan."""
         super().__init__(coordinator, scene, enabled_default=enabled_default)
-        self._default_dimming = default_dimming
+
+    @property
+    def _default_dimming(self) -> int:
+        """Return the configured default fan speed, read fresh from entry data."""
+        return _get_default_scene_fan_dimming(self.coordinator.config_entry).get(
+            self._scene_id, DEFAULT_SCENE_FAN_DIMMING
+        )
 
     async def _async_set_percentage(self, percentage: int | None) -> None:
         """Set fan speed. A percentage of 0 turns the fan off."""


### PR DESCRIPTION
Makes `TewkeSceneFan` entities dynamically fetch their default dimming setting from the config entry data each time it's accessed. This ensures that changes made to default dimming via the options flow are immediately reflected without requiring a full integration reload.

Consequently, the `async_reload_entry` listener, which previously forced a reload on options updates, can be safely removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved fan scene initialization and configuration management
  * Simplified entity enablement logic based on scene configuration
  * Optimized cleanup and shutdown behavior

* **Bug Fixes**
  * Fixed default fan dimming configuration handling for scene fans to read dynamically from settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tewke/ha-custom-integration/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->