### PR TITLE
refactor: Simplify scene control types update in repair flow

### DIFF
--- a/custom_components/tewke/repairs.py
+++ b/custom_components/tewke/repairs.py
@@ -173,7 +173,7 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
     ) -> FlowResult:
         """Commit all configured scene control types and update HA state."""
         pending: dict[str, Scene] = self.entry.runtime_data.pending_scenes
-        new_control_types = self.entry.runtime_data.scene_control_types.copy()
+        scene_control_types = self.entry.runtime_data.scene_control_types
         added_scenes: list[Scene] = []
         newly_disabled = []
         index_name_to_id = {
@@ -200,7 +200,7 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
 
             added_scenes.append(pending[scene_id])
 
-            new_control_types[scene_id] = scene_text
+            scene_control_types[scene_id] = scene_text
             if not enabled_text:
                 newly_disabled.append(scene_id)
 
@@ -220,17 +220,18 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
             self.entry,
             data={
                 **self.entry.data,
-                "scene_control_types": new_control_types,
+                "scene_control_types": scene_control_types,
                 CONF_DISABLED_SCENES: merged_disabled,
                 CONF_DEFAULT_SCENE_FAN_DIMMING: merged_fan_dimming,
             },
         )
-        self.entry.runtime_data.scene_control_types = new_control_types
 
         coordinator = self.entry.runtime_data.coordinator
         scenes_all = coordinator.data.get("scenes_all", {})
         configured_scenes = {
-            sid: scene for sid, scene in scenes_all.items() if sid in new_control_types
+            sid: scene
+            for sid, scene in scenes_all.items()
+            if sid in scene_control_types
         }
         coordinator.async_set_updated_data(
             {


### PR DESCRIPTION
Fix: Scene doesn't appear after repair

    Root cause: In repairs.py, _async_apply_results was doing:

     new_control_types = self.entry.runtime_data.scene_control_types.copy()  # new dict
     ...
     new_control_types[scene_id] = scene_text
     ...
     self.entry.runtime_data.scene_control_types = new_control_types  # reassigns to new dict

    All three platform setup functions (fan.py, light.py, switch.py) capture scene_control_types = entry.runtime_data.scene_control_types at setup time. Their _async_add_new_scenes closures hold a reference to the original dict. When runtime_data.scene_control_types gets replaced with a new dict, those
    closures are still pointing at the old one. So when DISPATCHER_ADD_SCENES fires and they check scene_control_types.get(scene.id), the new scene ID isn't found → entity is never added.

    Fix (repairs.py): Removed the .copy() and the reassignment. The code now mutates the existing dict in-place:

     scene_control_types = self.entry.runtime_data.scene_control_types
     ...
     scene_control_types[scene_id] = scene_text

    The closures in all three platforms now see the update immediately when the dispatcher fires.