### PR TITLE
fix: Ensure scene control types are correctly persisted and updated live

### DIFF
--- a/custom_components/tewke/fan.py
+++ b/custom_components/tewke/fan.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from .const import (
     CONF_DISABLED_SCENES,
     DISPATCHER_ADD_SCENES,
+    LOGGER,
 )
 from .scene import TewkeSceneFan
 
@@ -43,6 +44,14 @@ async def async_setup_entry(
 
     @callback
     def _async_add_new_scenes(scenes: list[Scene]) -> None:
+        fan_scenes = [s for s in scenes if scene_control_types.get(s.id) == "fan"]
+        LOGGER.debug(
+            "fan._async_add_new_scenes: received %s, fan matches=%s, "
+            "scene_control_types=%s",
+            [s.id for s in scenes],
+            [s.id for s in fan_scenes],
+            dict(scene_control_types),
+        )
         async_add_entities(
             TewkeSceneFan(
                 coordinator=coordinator,
@@ -50,8 +59,7 @@ async def async_setup_entry(
                 enabled_default=scene.id
                 not in entry.data.get(CONF_DISABLED_SCENES, []),
             )
-            for scene in scenes
-            if scene_control_types.get(scene.id) == "fan"
+            for scene in fan_scenes
         )
 
     entry.async_on_unload(

--- a/custom_components/tewke/light.py
+++ b/custom_components/tewke/light.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import CONF_DISABLED_SCENES, DISPATCHER_ADD_SCENES
+from .const import CONF_DISABLED_SCENES, DISPATCHER_ADD_SCENES, LOGGER
 from .scene import TewkeSceneLight
 from .target import TewkeTargetLight
 
@@ -46,6 +46,14 @@ async def async_setup_entry(
 
     @callback
     def _async_add_new_scenes(scenes: list[Scene]) -> None:
+        light_scenes = [s for s in scenes if scene_control_types.get(s.id) == "light"]
+        LOGGER.debug(
+            "light._async_add_new_scenes: received %s, light matches=%s, "
+            "scene_control_types=%s",
+            [s.id for s in scenes],
+            [s.id for s in light_scenes],
+            dict(scene_control_types),
+        )
         async_add_entities(
             TewkeSceneLight(
                 coordinator=coordinator,
@@ -53,8 +61,7 @@ async def async_setup_entry(
                 enabled_default=scene.id
                 not in entry.data.get(CONF_DISABLED_SCENES, []),
             )
-            for scene in scenes
-            if scene_control_types.get(scene.id) == "light"
+            for scene in light_scenes
         )
 
     entry.async_on_unload(

--- a/custom_components/tewke/repairs.py
+++ b/custom_components/tewke/repairs.py
@@ -181,6 +181,13 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
         }
         scene_configs = user_input.items()
 
+        # Collect new scene mappings into a copy so async_update_entry can detect
+        # the change (the live dict is the same object as
+        # entry.data["scene_control_types"], so mutating it in-place would make
+        # the comparison see "no change").
+        new_scene_ctrl: dict[str, str] = dict(scene_control_types)
+        new_scene_ids: list[tuple[str, str]] = []
+
         for index_name, config in scene_configs:
             if index_name not in index_name_to_id:
                 continue
@@ -199,12 +206,21 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
                 continue
 
             added_scenes.append(pending[scene_id])
-
-            scene_control_types[scene_id] = scene_text
+            new_scene_ctrl[scene_id] = scene_text
+            new_scene_ids.append((scene_id, scene_text))
             if not enabled_text:
                 newly_disabled.append(scene_id)
 
             del pending[scene_id]
+
+        LOGGER.debug(
+            "Repair apply: adding %d scene(s) %s; "
+            "scene_control_types before=%s after=%s",
+            len(added_scenes),
+            [s.id for s in added_scenes],
+            list(scene_control_types),
+            list(new_scene_ctrl),
+        )
 
         existing_disabled: list[str] = list(
             self.entry.data.get(CONF_DISABLED_SCENES, [])
@@ -216,15 +232,23 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
         existing_fan_dimming = _get_default_scene_fan_dimming(self.entry)
         merged_fan_dimming = {**existing_fan_dimming, **(fan_dimming or {})}
 
+        # Persist with the new copy — entry.data["scene_control_types"] currently
+        # points to the live dict (no mutation yet) so the diff is detected correctly.
         self.hass.config_entries.async_update_entry(
             self.entry,
             data={
                 **self.entry.data,
-                "scene_control_types": scene_control_types,
+                "scene_control_types": new_scene_ctrl,
                 CONF_DISABLED_SCENES: merged_disabled,
                 CONF_DEFAULT_SCENE_FAN_DIMMING: merged_fan_dimming,
             },
         )
+
+        # Now apply the same changes to the live dict so platform closures
+        # (fan.py / light.py / switch.py) — which captured this dict at setup
+        # time — see the updated mappings immediately.
+        for sid, text in new_scene_ids:
+            scene_control_types[sid] = text
 
         coordinator = self.entry.runtime_data.coordinator
         scenes_all = coordinator.data.get("scenes_all", {})
@@ -233,6 +257,11 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
             for sid, scene in scenes_all.items()
             if sid in scene_control_types
         }
+        LOGGER.debug(
+            "Repair apply: scenes_all keys=%s, configured_scenes keys=%s",
+            list(scenes_all),
+            list(configured_scenes),
+        )
         coordinator.async_set_updated_data(
             {
                 **coordinator.data,
@@ -241,6 +270,10 @@ class TewkeNewSceneRepairFlow(RepairsFlow):
         )
 
         if added_scenes:
+            LOGGER.debug(
+                "Repair apply: dispatching ADD_SCENES for %s",
+                [s.id for s in added_scenes],
+            )
             async_dispatcher_send(self.hass, DISPATCHER_ADD_SCENES, added_scenes)
 
         if not pending:

--- a/custom_components/tewke/scene.py
+++ b/custom_components/tewke/scene.py
@@ -56,7 +56,16 @@ class TewkeSceneEntity(TewkeEntity):
         super().__init__(coordinator)
         self._scene_id = scene.id
         self._attr_name = scene.name
-        hardware_id = coordinator.data["config"].hardware_id
+        config = coordinator.data["config"]
+        if config is None:
+            LOGGER.error(
+                "Cannot create scene entity for %s: config data is None "
+                "(hardware_id unavailable)",
+                scene.id,
+            )
+            msg = f"config data is None for scene {scene.id}"
+            raise RuntimeError(msg)
+        hardware_id = config.hardware_id
         self._attr_unique_id = f"{hardware_id}_{scene.id}"
         self._is_on = scene.is_active
         self._brightness: int | None = scene.brightness

--- a/custom_components/tewke/switch.py
+++ b/custom_components/tewke/switch.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import CONF_DISABLED_SCENES, DISPATCHER_ADD_SCENES
+from .const import CONF_DISABLED_SCENES, DISPATCHER_ADD_SCENES, LOGGER
 from .scene import TewkeSceneSwitch
 
 if TYPE_CHECKING:
@@ -40,6 +40,16 @@ async def async_setup_entry(
 
     @callback
     def _async_add_new_scenes(scenes: list[Scene]) -> None:
+        switch_scenes = [
+            s for s in scenes if scene_control_types.get(s.id) == "switch"
+        ]
+        LOGGER.debug(
+            "switch._async_add_new_scenes: received %s, switch matches=%s, "
+            "scene_control_types=%s",
+            [s.id for s in scenes],
+            [s.id for s in switch_scenes],
+            dict(scene_control_types),
+        )
         async_add_entities(
             TewkeSceneSwitch(
                 coordinator=coordinator,
@@ -47,8 +57,7 @@ async def async_setup_entry(
                 enabled_default=scene.id
                 not in entry.data.get(CONF_DISABLED_SCENES, []),
             )
-            for scene in scenes
-            if scene_control_types.get(scene.id) == "switch"
+            for scene in switch_scenes
         )
 
     entry.async_on_unload(

--- a/custom_components/tewke/util.py
+++ b/custom_components/tewke/util.py
@@ -95,13 +95,20 @@ async def async_setup_observe(  # noqa: PLR0915
             LOGGER.info(
                 "Marking deleted scenes as unavailable: %s", removed_configured_ids
             )
-            new_scene_control_types = dict(scene_control_types)
 
-            for sid in removed_configured_ids:
-                del new_scene_control_types[sid]
+            # Build a copy of scene_control_types *before* mutating the live
+            # dict so async_update_entry can detect the change
+            # (entry.data["scene_control_types"] is the same object as the live
+            # dict, so in-place mutation would make the comparison see "no change"
+            # and skip the save).
+            new_scene_ctrl = {
+                sid: text
+                for sid, text in scene_control_types.items()
+                if sid not in removed_configured_ids
+            }
 
             new_data = dict(entry.data)
-            new_data["scene_control_types"] = new_scene_control_types
+            new_data["scene_control_types"] = new_scene_ctrl
 
             if CONF_DISABLED_SCENES in new_data:
                 new_data[CONF_DISABLED_SCENES] = [
@@ -115,9 +122,12 @@ async def async_setup_observe(  # noqa: PLR0915
                     new_fan_dimming.pop(sid, None)
                 new_data[CONF_DEFAULT_SCENE_FAN_DIMMING] = new_fan_dimming
 
-            entry.runtime_data.scene_control_types = new_scene_control_types
             hass.config_entries.async_update_entry(entry, data=new_data)
-            return
+
+            # Mutate the live dict *after* persisting so platform closures see the
+            # removal immediately, while the persistence diff above was correct.
+            for sid in removed_configured_ids:
+                del scene_control_types[sid]
 
         configured_scenes = {
             scene_id: scene
@@ -125,6 +135,13 @@ async def async_setup_observe(  # noqa: PLR0915
             if scene_id in scene_control_types
         }
 
+        LOGGER.debug(
+            "_on_scene_update: device_scenes=%s, scene_control_types=%s, "
+            "configured=%s",
+            list(scenes),
+            list(scene_control_types),
+            list(configured_scenes),
+        )
         coordinator.async_set_updated_data(
             {
                 **coordinator.data,


### PR DESCRIPTION
The previous approach to updating `scene_control_types` could lead to inconsistencies where changes might not be persisted to the configuration entry or not immediately visible to all components holding references to the live dictionary.

This commit refines the update mechanism in repair flows and scene observation to correctly handle both requirements:
1.  **Persistence:** `hass.config_entries.async_update_entry` now receives a *new* dictionary object for `scene_control_types` within `entry.data`. This ensures Home Assistant's config entry system detects the change and persists it.
2.  **Live Updates:** Immediately after the persistence call, the original `scene_control_types` dictionary (which platform closures and other live components reference) is explicitly mutated in-place with the new values. This guarantees immediate reflection of changes across the integration without requiring a full reload.

This addresses scenarios where newly configured or updated scenes might not appear correctly, or deleted scenes might remain visible, due to stale references or unpersisted configuration.

Additionally, extensive debug logging has been added to `fan.py`, `light.py`, `switch.py`, `repairs.py`, and `util.py` to aid in future troubleshooting of scene update flows. A defensive check was also added in `scene.py` to prevent entity creation with missing configuration data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scene configuration handling to prevent crashes when critical data is missing.
  * Enhanced scene removal and update logic for more reliable configuration persistence.

* **Refactor**
  * Optimized scene filtering and categorization during entity creation.
  * Improved configuration update workflow to ensure platform-level changes are applied correctly.

* **Chores**
  * Enhanced debug logging throughout scene management for better troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tewke/ha-custom-integration/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->